### PR TITLE
CZI support of multiple sections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,8 @@
 		<package-name>net.imglib2.labkit</package-name>
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>Matthias Arzt, Philipp Hanslovsky</license.copyrightOwners>
-		<bigdataviewer-vistools.version>1.0.0-beta-6</bigdataviewer-vistools.version>
+		<bigdataviewer-vistools.version>1.0.0-beta-10</bigdataviewer-vistools.version>
+		<bigdataviewer-core.version>4.3.2</bigdataviewer-core.version>
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>ome</groupId>
+			<artifactId>bioformats_package</artifactId>
+			<version>5.8.0</version>
+		</dependency>
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/net/imglib2/labkit/InitialLabeling.java
+++ b/src/main/java/net/imglib2/labkit/InitialLabeling.java
@@ -19,9 +19,9 @@ import java.util.stream.LongStream;
 public class InitialLabeling {
 	static Labeling initLabeling(InputImage inputImage, Context context, List<String> defaultLabels) {
 		String filename = inputImage.getLabelingName();
-		if(new File(filename + ".labeling").exists()) {
+		if(new File(filename).exists()) {
 			try {
-				return new LabelingSerializer(context).open(filename + ".labeling");
+				return new LabelingSerializer(context).open(filename);
 			} catch (IOException e) {
 				e.printStackTrace();
 			}

--- a/src/main/java/net/imglib2/labkit/InitialLabeling.java
+++ b/src/main/java/net/imglib2/labkit/InitialLabeling.java
@@ -18,7 +18,7 @@ import java.util.stream.LongStream;
 
 public class InitialLabeling {
 	static Labeling initLabeling(InputImage inputImage, Context context, List<String> defaultLabels) {
-		String filename = inputImage.getFilename();
+		String filename = inputImage.getLabelingName();
 		if(new File(filename + ".labeling").exists()) {
 			try {
 				return new LabelingSerializer(context).open(filename + ".labeling");

--- a/src/main/java/net/imglib2/labkit/LabelingComponent.java
+++ b/src/main/java/net/imglib2/labkit/LabelingComponent.java
@@ -39,8 +39,8 @@ public class LabelingComponent implements AutoCloseable {
 		return actionsAndBehaviours.getActions();
 	}
 
-	LabelingComponent(final JFrame dialogBoxOwner,
-			final ImageLabelingModel model)
+	public LabelingComponent( final JFrame dialogBoxOwner,
+			final ImageLabelingModel model )
 	{
 		this.model = model;
 		this.dialogBoxOwner = dialogBoxOwner;
@@ -119,6 +119,6 @@ public class LabelingComponent implements AutoCloseable {
 	@Override
 	public void close()
 	{
-		bdvHandle.getViewerPanel().stop();
+		bdvHandle.close();
 	}
 }

--- a/src/main/java/net/imglib2/labkit/actions/LabelingIoAction.java
+++ b/src/main/java/net/imglib2/labkit/actions/LabelingIoAction.java
@@ -28,7 +28,7 @@ public class LabelingIoAction extends AbstractFileIoAcion {
 		initSaveAction("Save Labeling ...", "saveLabeling", new Action() {
 			@Override
 			public String suggestedFile() {
-				return inputImage.getLabelingName() + ".labeling";
+				return inputImage.getLabelingName();
 			}
 
 			@Override

--- a/src/main/java/net/imglib2/labkit/actions/LabelingIoAction.java
+++ b/src/main/java/net/imglib2/labkit/actions/LabelingIoAction.java
@@ -28,7 +28,7 @@ public class LabelingIoAction extends AbstractFileIoAcion {
 		initSaveAction("Save Labeling ...", "saveLabeling", new Action() {
 			@Override
 			public String suggestedFile() {
-				return inputImage.getFilename() + ".labeling";
+				return inputImage.getLabelingName() + ".labeling";
 			}
 
 			@Override

--- a/src/main/java/net/imglib2/labkit/inputimage/DatasetInputImage.java
+++ b/src/main/java/net/imglib2/labkit/inputimage/DatasetInputImage.java
@@ -20,16 +20,16 @@ public class DatasetInputImage extends AbstractInputImage {
 
 	private final ImgPlus<?> image;
 	private boolean isTimeSeries;
-	private Integer sectionIndex;
+	private String labelingName;
 
-	public DatasetInputImage(ImgPlus<?> image, Integer sectionIndex) {
+	public DatasetInputImage(ImgPlus<?> image) {
 		this.image = image;
 		this.isTimeSeries = image.dimensionIndex(Axes.TIME) >= 0;
-		this.sectionIndex = sectionIndex;
+		this.labelingName = image.getSource() + ".labeling";
 	}
 
-	public DatasetInputImage(Dataset image) {
-		this(image.getImgPlus(), null);
+	public DatasetInputImage(Dataset dataset) {
+		this(dataset.getImgPlus());
 	}
 
 	@Override
@@ -77,15 +77,13 @@ public class DatasetInputImage extends AbstractInputImage {
 		return image.numDimensions() - (isTimeSeries() ? 1 : 0) - (hasColorChannel() ? 1 : 0);
 	}
 
+	public void setLabelingName(String labelingName) {
+		this.labelingName = labelingName;
+	}
+
 	@Override
 	public String getLabelingName() {
-		if(image.getSource().contains(".czi")){
-			String labelingName = image.getSource().replace(".czi", "");
-			if(sectionIndex != null)
-				labelingName += "-" + (sectionIndex + 1);
-			return labelingName+".czi";
-		}
-		return image.getSource() + ".labeling";
+		return labelingName;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/labkit/inputimage/DatasetInputImage.java
+++ b/src/main/java/net/imglib2/labkit/inputimage/DatasetInputImage.java
@@ -20,16 +20,16 @@ public class DatasetInputImage extends AbstractInputImage {
 
 	private final ImgPlus<?> image;
 	private boolean isTimeSeries;
-	private int sectionIndex;
+	private Integer sectionIndex;
 
-	public DatasetInputImage(ImgPlus<?> image, int sectionIndex) {
+	public DatasetInputImage(ImgPlus<?> image, Integer sectionIndex) {
 		this.image = image;
 		this.isTimeSeries = image.dimensionIndex(Axes.TIME) >= 0;
 		this.sectionIndex = sectionIndex;
 	}
 
 	public DatasetInputImage(Dataset image) {
-		this(image.getImgPlus(), 0);
+		this(image.getImgPlus(), null);
 	}
 
 	@Override
@@ -81,8 +81,8 @@ public class DatasetInputImage extends AbstractInputImage {
 	public String getLabelingName() {
 		if(image.getSource().contains(".czi")){
 			String labelingName = image.getSource().replace(".czi", "");
-			if(sectionIndex > 0)
-				labelingName += "-" + sectionIndex;
+			if(sectionIndex != null)
+				labelingName += "-" + (sectionIndex + 1);
 			return labelingName+".czi";
 		}
 		return image.getSource();

--- a/src/main/java/net/imglib2/labkit/inputimage/DatasetInputImage.java
+++ b/src/main/java/net/imglib2/labkit/inputimage/DatasetInputImage.java
@@ -85,7 +85,7 @@ public class DatasetInputImage extends AbstractInputImage {
 				labelingName += "-" + (sectionIndex + 1);
 			return labelingName+".czi";
 		}
-		return image.getSource();
+		return image.getSource() + ".labeling";
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/labkit/inputimage/DatasetInputImage.java
+++ b/src/main/java/net/imglib2/labkit/inputimage/DatasetInputImage.java
@@ -20,14 +20,16 @@ public class DatasetInputImage extends AbstractInputImage {
 
 	private final ImgPlus<?> image;
 	private boolean isTimeSeries;
+	private int sectionIndex;
 
-	public DatasetInputImage(ImgPlus<?> image) {
+	public DatasetInputImage(ImgPlus<?> image, int sectionIndex) {
 		this.image = image;
 		this.isTimeSeries = image.dimensionIndex(Axes.TIME) >= 0;
+		this.sectionIndex = sectionIndex;
 	}
 
 	public DatasetInputImage(Dataset image) {
-		this(image.getImgPlus());
+		this(image.getImgPlus(), 0);
 	}
 
 	@Override
@@ -76,7 +78,13 @@ public class DatasetInputImage extends AbstractInputImage {
 	}
 
 	@Override
-	public String getFilename() {
+	public String getLabelingName() {
+		if(image.getSource().contains(".czi")){
+			String labelingName = image.getSource().replace(".czi", "");
+			if(sectionIndex > 0)
+				labelingName += "-" + sectionIndex;
+			return labelingName+".czi";
+		}
 		return image.getSource();
 	}
 

--- a/src/main/java/net/imglib2/labkit/inputimage/DefaultInputImage.java
+++ b/src/main/java/net/imglib2/labkit/inputimage/DefaultInputImage.java
@@ -44,7 +44,7 @@ public class DefaultInputImage extends AbstractInputImage {
 
 	@Override
 	public String getLabelingName() {
-		return filename;
+		return filename + ".labeling";
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/labkit/inputimage/DefaultInputImage.java
+++ b/src/main/java/net/imglib2/labkit/inputimage/DefaultInputImage.java
@@ -43,7 +43,7 @@ public class DefaultInputImage extends AbstractInputImage {
 	}
 
 	@Override
-	public String getFilename() {
+	public String getLabelingName() {
 		return filename;
 	}
 

--- a/src/main/java/net/imglib2/labkit/inputimage/InputImage.java
+++ b/src/main/java/net/imglib2/labkit/inputimage/InputImage.java
@@ -14,7 +14,7 @@ public interface InputImage {
 
 	int getSpatialDimensions();
 
-	String getFilename();
+	String getLabelingName();
 
 	String getName();
 

--- a/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
+++ b/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
@@ -19,6 +19,7 @@ import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.labkit.plugin.ui.SectionsDialog;
 import net.imglib2.labkit.utils.ParallelUtils;
 import net.imglib2.trainable_segmention.RevampUtils;
 import net.imglib2.type.numeric.ARGBType;
@@ -31,13 +32,13 @@ import ome.xml.model.primitives.PositiveInteger;
 
 import javax.swing.*;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executors;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class BFTiledImport {
 
@@ -47,7 +48,8 @@ public class BFTiledImport {
 	}
 
 	public static ImgPlus<ARGBType> openImage(String filename) {
-		final int series = selectSeries(filename);
+		final int[] sectionIds = selectSection(filename);
+		final int series = selectSectionResolution(filename, sectionIds);
 		MyReader reader = new MyReader( filename );
 		long[] dimensions = reader.getImgDimensions( series );
 		int[] cellDimensions = reader.getCellDimensions( series );
@@ -64,16 +66,28 @@ public class BFTiledImport {
 		return imgPlus;
 	}
 
-	private static int selectSeries(String filename) {
+	private static int[] selectSection(String filename) {
 		ImageReader reader = initReader(filename);
-		List<String> list = IntStream.range(0, reader.getSeriesCount()).mapToObj(series -> {
+		SectionsDialog dialog = new SectionsDialog(reader);
+		dialog.showDialog();
+		return dialog.getSelectedSectionIndices();
+	}
+
+	private static int selectSectionResolution(String filename, int[] sectionIds) {
+		ImageReader reader = initReader(filename);
+		List<String> list = Arrays.stream(sectionIds).mapToObj(series -> {
 			reader.setSeries(series);
 			return reader.getSizeX() + " x " + reader.getSizeY();
 		}).collect(Collectors.toList());
 		Object result = JOptionPane.showInputDialog(null, "Select Image Resolution", "Labkit - Import Image", JOptionPane.PLAIN_MESSAGE, null, list.toArray(), list.get(0));
 		if(result == null)
 			throw new CancellationException();
-		return list.indexOf(result);
+		for(int i = 0; i < list.size(); i++) {
+			if(list.get(i).equals(result)) {
+				return sectionIds[i];
+			}
+		}
+		return -1;
 	}
 
 	// -- Helper methods --

--- a/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
+++ b/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
@@ -53,16 +53,10 @@ public class BFTiledImport {
 
 	public static Section openImage(String filename) {
 		MyReader reader = new MyReader( filename );
-		SectionsDialog dialog = new SectionsDialog(initReader(filename), filename);
-		dialog.pack();
-		dialog.setLocationRelativeTo(null);
-		dialog.setVisible(true);
-		int[] sectionIds = dialog.getSelectedSectionIndices();
-		if(sectionIds == null) {
-			throw new CancellationException();
-		}
+		SectionsDialog dialog = SectionsDialog.show(initReader(filename));
 		Section res = new Section();
 		res.index = dialog.getSelectedSection();
+		int[] sectionIds = dialog.getSelectedSectionIndices();
 		final int series = selectSectionResolution(filename, sectionIds);
 		long[] dimensions = reader.getImgDimensions( series );
 		int[] cellDimensions = reader.getCellDimensions( series );

--- a/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
+++ b/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
@@ -56,7 +56,7 @@ public class BFTiledImport {
 		SectionsDialog dialog = SectionsDialog.show(initReader(filename));
 		Section res = new Section();
 		res.index = dialog.getSelectedSection();
-		int[] sectionIds = dialog.getSelectedSectionIndices();
+		List<Integer> sectionIds = dialog.getSelectedSectionIndices();
 		final int series = selectSectionResolution(filename, sectionIds);
 		long[] dimensions = reader.getImgDimensions( series );
 		int[] cellDimensions = reader.getCellDimensions( series );
@@ -74,9 +74,9 @@ public class BFTiledImport {
 		return imgPlus;
 	}
 
-	private static int selectSectionResolution(String filename, int[] sectionIds) {
+	private static int selectSectionResolution(String filename, List<Integer> sectionIds) {
 		ImageReader reader = initReader(filename);
-		List<String> list = Arrays.stream(sectionIds).mapToObj(series -> {
+		List<String> list = sectionIds.stream().map(series -> {
 			reader.setSeries(series);
 			return reader.getSizeX() + " x " + reader.getSizeY();
 		}).collect(Collectors.toList());
@@ -85,7 +85,7 @@ public class BFTiledImport {
 			throw new CancellationException();
 		for(int i = 0; i < list.size(); i++) {
 			if(list.get(i).equals(result)) {
-				return sectionIds[i];
+				return sectionIds.get(i);
 			}
 		}
 		return -1;

--- a/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
+++ b/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
@@ -2,7 +2,6 @@ package net.imglib2.labkit.plugin;
 
 import bdv.util.Bdv;
 import bdv.util.BdvFunctions;
-import bdv.util.BdvOptions;
 import loci.formats.ClassList;
 import loci.formats.FormatException;
 import loci.formats.IFormatReader;
@@ -114,20 +113,19 @@ public class BFTiledImport {
 
 	private static class MyReader {
 
-		private final ThreadLocal< ImageReader > readers;
+		private final ImageReader reader;
 
 		private final IMetadata metadata;
 
 		public MyReader(String filename) {
-			readers = ThreadLocal.withInitial(() -> initReader(filename) );
 			ValuePair< ImageReader, IMetadata > readerAndMetaData = initReaderAndMetaData( filename );
-			readers.set( readerAndMetaData.getA() );
+			reader = readerAndMetaData.getA();
 			metadata = readerAndMetaData.getB();
 		}
 
 		private ImageReader getReader( int series )
 		{
-			ImageReader reader = readers.get();
+			ImageReader reader = this.reader;
 			reader.setSeries( series );
 			return reader;
 		}

--- a/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
+++ b/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
@@ -1,6 +1,8 @@
 package net.imglib2.labkit.plugin;
 
+import bdv.util.Bdv;
 import bdv.util.BdvFunctions;
+import bdv.util.BdvOptions;
 import loci.formats.ClassList;
 import loci.formats.FormatException;
 import loci.formats.IFormatReader;
@@ -17,11 +19,12 @@ import net.imagej.axis.DefaultLinearAxis;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
-import net.imglib2.img.cell.CellGrid;
 import net.imglib2.img.cell.CellImgFactory;
 import net.imglib2.labkit.utils.ParallelUtils;
+import net.imglib2.trainable_segmention.RevampUtils;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.util.Intervals;
+import net.imglib2.util.ValuePair;
 import net.imglib2.view.Views;
 import ome.units.UNITS;
 import ome.units.quantity.Length;
@@ -41,66 +44,25 @@ public class BFTiledImport {
 
 	public static void main(String... args) throws IOException, FormatException {
 		ImgPlus<ARGBType> out = openImage("/home/arzt/Documents/Datasets/Lung IMages/2017_08_03__0004-1.czi");
-		BdvFunctions.show(out, "Image");
+		BdvFunctions.show(out, "Image", Bdv.options().is2D());
 	}
 
-	static ImgPlus<ARGBType> openImage(String filename) {
+	public static ImgPlus<ARGBType> openImage(String filename) {
 		final int series = selectSeries(filename);
-		ThreadLocal<ImageReader> tl = ThreadLocal.withInitial(() -> {
-			ImageReader reader = initReader(filename);
-			reader.setSeries(series);
-			return reader;
-		});
-		ImageReader reader = tl.get();
-		int sizeX = reader.getSizeX();
-		int sizeY = reader.getSizeY();
-		int[] cellDimensions = {1024, 1024};
-		CellGrid grid = new CellGrid(new long[]{sizeX, sizeY}, cellDimensions);
-		Img<ARGBType> out = new CellImgFactory<ARGBType>(cellDimensions).create(
-				grid.getImgDimensions(), new ARGBType()
-		);
-		List<Callable<Void>> chunks = ParallelUtils.chunkOperation(out, cellDimensions, cell -> {
-			try {
-				readToInterval(tl.get(), cell);
-			} catch (FormatException | IOException e) {
-				throw new RuntimeException(e);
-			}
-		});
+		MyReader reader = new MyReader( filename );
+		long[] dimensions = reader.getImgDimensions( series );
+		int[] cellDimensions = reader.getCellDimensions( series );
+		Img<ARGBType> out = new CellImgFactory<ARGBType>(cellDimensions).create( dimensions, new ARGBType() );
+		List<Callable<Void>> chunks = ParallelUtils.chunkOperation(out, cellDimensions, cell -> reader.readToInterval( series, cell ) );
 		ParallelUtils.executeInParallel(Executors.newFixedThreadPool(8), ParallelUtils.addShowProgress(chunks));
-		CalibratedAxis[] axis = printCalibration(filename, series);
+		return imgPlus( filename, out, reader.printCalibration( series ) );
+	}
+
+	private static ImgPlus< ARGBType > imgPlus( String filename, Img< ARGBType > out, CalibratedAxis[] axis )
+	{
 		ImgPlus<ARGBType> imgPlus = new ImgPlus<>(out, filename, axis);
 		imgPlus.setSource(filename);
 		return imgPlus;
-	}
-
-	private static CalibratedAxis[] printCalibration(String filename, int series) {
-		ClassList<IFormatReader> cl = new ClassList<>(IFormatReader.class);
-		cl.addClass(JPEGReader.class);
-		cl.addClass(ZeissCZIReader.class);
-		ImageReader reader = new ImageReader(cl);
-		IMetadata metadata = MetadataTools.createOMEXMLMetadata();
-		reader.setMetadataStore(metadata);
-		try {
-			reader.setId(filename);
-		} catch (FormatException | IOException e) {
-			throw new RuntimeException(e);
-		}
-		return new CalibratedAxis[] {
-				initAxis(Axes.X, series, metadata::getPixelsPhysicalSizeX, metadata::getPixelsSizeX),
-				initAxis(Axes.Y, series, metadata::getPixelsPhysicalSizeY, metadata::getPixelsSizeY)
-		};
-	}
-
-	private static DefaultLinearAxis initAxis(AxisType axisType, int series, IntFunction<Length> pixelSize, IntFunction<PositiveInteger> imageSize) {
-		// NB: metadata.getPixelsPhysicalSizeX/Y return the same pixel size for each image in the resolution pyramid
-		// The following 4 lines of code, calculate the correct pixel size for the scaled down images.
-		// This is a workaround until metadata.getPixelPysicalSizeX/Y are fixed.
-		double fullResolutionPixelSize = pixelSize.apply(0).value(UNITS.MICROMETER).doubleValue();
-		double fullResolutionImageSize = imageSize.apply(0).getValue();
-		double lowResolutionImageSize = imageSize.apply(series).getValue();
-		double lowResolutionPixelSize = fullResolutionPixelSize * fullResolutionImageSize / lowResolutionImageSize;
-		System.out.println("Axis " + axisType + " = " + lowResolutionPixelSize + "microm");
-		return new DefaultLinearAxis(axisType, "microm", lowResolutionPixelSize);
 	}
 
 	private static int selectSeries(String filename) {
@@ -115,29 +77,102 @@ public class BFTiledImport {
 		return list.indexOf(result);
 	}
 
+	// -- Helper methods --
+
 	private static ImageReader initReader(String filename) {
+		ImageReader reader = initReader();
+		readerSetFile( reader, filename );
+		return reader;
+	}
+
+	private static ValuePair<ImageReader, IMetadata> initReaderAndMetaData(String filename) {
+		ImageReader reader = initReader();
+		IMetadata metadata = MetadataTools.createOMEXMLMetadata();
+		reader.setMetadataStore( metadata );
+		readerSetFile( reader, filename );
+		return new ValuePair<>( reader, metadata );
+	}
+
+	private static void readerSetFile( ImageReader reader, String filename )
+	{
 		try {
-			ClassList<IFormatReader> cl = new ClassList<>(IFormatReader.class);
-			cl.addClass(JPEGReader.class);
-			cl.addClass(ZeissCZIReader.class);
-			ImageReader reader = new ImageReader(cl);
 			reader.setId(filename);
-			return reader;
 		} catch (FormatException | IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-	private static void readToInterval(ImageReader reader, RandomAccessibleInterval<ARGBType> interval) throws FormatException, IOException {
-		int[] min = Intervals.minAsIntArray(interval);
-		int[] size = Intervals.dimensionsAsIntArray(interval);
-		byte[] bytes = reader.openBytes(0, min[0], min[1], size[0], size[1]);
-		Cursor<ARGBType> cursor = Views.flatIterable(interval).cursor();
-		int index = 0;
-		while(cursor.hasNext()) {
-			int color = ARGBType.rgba(bytes[index], bytes[index + 1], bytes[index + 2], 255);
-			cursor.next().set(color);
-			index += 3;
+	private static ImageReader initReader()
+	{
+		ClassList<IFormatReader> cl = new ClassList<>(IFormatReader.class);
+		cl.addClass(JPEGReader.class);
+		cl.addClass(ZeissCZIReader.class);
+		return new ImageReader(cl);
+	}
+
+	// -- Helper classes --
+
+	private static class MyReader {
+
+		private final ThreadLocal< ImageReader > readers;
+
+		private final IMetadata metadata;
+
+		public MyReader(String filename) {
+			readers = ThreadLocal.withInitial(() -> initReader(filename) );
+			ValuePair< ImageReader, IMetadata > readerAndMetaData = initReaderAndMetaData( filename );
+			readers.set( readerAndMetaData.getA() );
+			metadata = readerAndMetaData.getB();
+		}
+
+		private ImageReader getReader( int series )
+		{
+			ImageReader reader = readers.get();
+			reader.setSeries( series );
+			return reader;
+		}
+
+		private long[] getImgDimensions( int series ) {
+			ImageReader reader = getReader( series );
+			return new long[] { reader.getSizeX(), reader.getSizeY() };
+		}
+
+		private int[] getCellDimensions( int series) {
+			ImageReader reader = getReader( series );
+			return new int[] { reader.getOptimalTileWidth(), reader.getOptimalTileHeight() };
+		}
+
+		private void readToInterval(int series, RandomAccessibleInterval<ARGBType> interval) {
+			int[] min = Intervals.minAsIntArray(interval);
+			int[] size = Intervals.dimensionsAsIntArray(interval);
+			ImageReader reader = getReader( series );
+			byte[] bytes = RevampUtils.wrapException( () -> reader.openBytes(0, min[0], min[1], size[0], size[1]) );
+			Cursor<ARGBType> cursor = Views.flatIterable(interval).cursor();
+			int index = 0;
+			while(cursor.hasNext()) {
+				int color = ARGBType.rgba(bytes[index], bytes[index + 1], bytes[index + 2], 255);
+				cursor.next().set(color);
+				index += 3;
+			}
+		}
+
+		private CalibratedAxis[] printCalibration(int series) {
+			return new CalibratedAxis[] {
+					initAxis(Axes.X, series, metadata::getPixelsPhysicalSizeX, metadata::getPixelsSizeX),
+					initAxis(Axes.Y, series, metadata::getPixelsPhysicalSizeY, metadata::getPixelsSizeY)
+			};
+		}
+
+		private static DefaultLinearAxis initAxis(AxisType axisType, int series, IntFunction<Length> pixelSize, IntFunction<PositiveInteger> imageSize) {
+			// NB: metadata.getPixelsPhysicalSizeX/Y return the same pixel size for each image in the resolution pyramid
+			// The following 4 lines of code, calculate the correct pixel size for the scaled down images.
+			// This is a workaround until metadata.getPixelPysicalSizeX/Y are fixed.
+			double fullResolutionPixelSize = pixelSize.apply(0).value(UNITS.MICROMETER).doubleValue();
+			double fullResolutionImageSize = imageSize.apply(0).getValue();
+			double lowResolutionImageSize = imageSize.apply(series).getValue();
+			double lowResolutionPixelSize = fullResolutionPixelSize * fullResolutionImageSize / lowResolutionImageSize;
+			System.out.println("Axis " + axisType + " = " + lowResolutionPixelSize + "microm");
+			return new DefaultLinearAxis(axisType, "microm", lowResolutionPixelSize);
 		}
 	}
 }

--- a/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
+++ b/src/main/java/net/imglib2/labkit/plugin/BFTiledImport.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 public class BFTiledImport {
 
 	public static class Section {
-		public int index;
+		public Integer index;
 		public ImgPlus<ARGBType> image;
 	}
 

--- a/src/main/java/net/imglib2/labkit/plugin/LabkitImportPlugin.java
+++ b/src/main/java/net/imglib2/labkit/plugin/LabkitImportPlugin.java
@@ -1,9 +1,7 @@
 package net.imglib2.labkit.plugin;
 
-import net.imagej.Dataset;
 import net.imglib2.labkit.MainFrame;
 import net.imglib2.labkit.inputimage.DatasetInputImage;
-import net.imglib2.labkit.inputimage.DefaultInputImage;
 import org.scijava.Context;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
@@ -30,8 +28,18 @@ public class LabkitImportPlugin implements Command {
 
 	private static void run(Context context, File file) {
 		BFTiledImport.Section section = BFTiledImport.openImage(file.getAbsolutePath());
-		DatasetInputImage image = new DatasetInputImage(section.image, section.index);
+		DatasetInputImage image = new DatasetInputImage(section.image);
+		image.setLabelingName(getLabelingName(section));
 		new MainFrame(context, image);
+	}
+
+	private static String getLabelingName(BFTiledImport.Section section) {
+		String source = section.image.getSource();
+		if(source.endsWith(".czi") && section.index != null) {
+			return source.substring(0, source.length() - ".czi".length())
+					+ "-" + (section.index + 1) + ".czi.labeling";
+		}
+		return source + ".labeling";
 	}
 
 	public static void main(String... args) {

--- a/src/main/java/net/imglib2/labkit/plugin/LabkitImportPlugin.java
+++ b/src/main/java/net/imglib2/labkit/plugin/LabkitImportPlugin.java
@@ -29,7 +29,8 @@ public class LabkitImportPlugin implements Command {
 	}
 
 	private static void run(Context context, File file) {
-		DatasetInputImage image = new DatasetInputImage(BFTiledImport.openImage(file.getAbsolutePath()));
+		BFTiledImport.Section section = BFTiledImport.openImage(file.getAbsolutePath());
+		DatasetInputImage image = new DatasetInputImage(section.image, section.index);
 		new MainFrame(context, image);
 	}
 

--- a/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
+++ b/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
@@ -99,11 +99,6 @@ public class SectionsDialog extends JDialog {
 							return;
 						}
 					}
-
-//          JOptionPane.showMessageDialog(this,
-//                  "Please select a section",
-//                  "No selection warning",
-//                  JOptionPane.WARNING_MESSAGE);
 				}
 				if (e.getNewValue().equals(JOptionPane.CANCEL_OPTION)) {
 					setVisible(false);
@@ -148,8 +143,6 @@ public class SectionsDialog extends JDialog {
 	}
 
 	private Component thumbPanel(int index) {
-		int sx = thumbReader.getThumbSizeX() + 10; // a little extra padding
-		int sy = thumbReader.getThumbSizeY();
 		Panel thumbPanel = new Panel();
 		ThumbLoader.loadThumb(thumbReader, index, thumbPanel, false);
 		return thumbPanel;

--- a/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
+++ b/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
@@ -12,8 +12,21 @@ import java.awt.event.WindowEvent;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 
 public class SectionsDialog extends JDialog {
+
+	public static SectionsDialog show(ImageReader reader1) {
+		SectionsDialog dialog = new SectionsDialog(reader1, reader1.getCurrentFile());
+		dialog.pack();
+		dialog.setLocationRelativeTo(null);
+		dialog.setVisible(true);
+		int[] sectionIds = dialog.getSelectedSectionIndices();
+		if(sectionIds == null) {
+			throw new CancellationException();
+		}
+		return dialog;
+	}
 
 	private BufferedImageReader thumbReader;
 	private List<JRadioButton> boxes;
@@ -24,7 +37,7 @@ public class SectionsDialog extends JDialog {
 
 	private JOptionPane optionPane;
 
-	public SectionsDialog(ImageReader reader, String filename) {
+	private SectionsDialog(ImageReader reader, String filename) {
 		setTitle("Select a section");
 
 		setModal(true);

--- a/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
+++ b/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
@@ -28,7 +28,7 @@ public class SectionsDialog {
 	private List<List<Integer>> sectionIndices;
 	private final ButtonGroup buttonGroup;
 
-	private Integer selectedSection = null;
+	private int selectedSection = 0;
 
 	private JComponent component;
 
@@ -81,9 +81,8 @@ public class SectionsDialog {
 		return selectedSection;
 	}
 
-	public int[] getSelectedSectionIndices() {
-		// TODO use list instead
-		return sectionIndices.get(selectedSection).stream().mapToInt(i -> i).toArray();
+	public List<Integer> getSelectedSectionIndices() {
+		return sectionIndices.get(selectedSection);
 	}
 
 	public Panel createSections(String filename) {

--- a/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
+++ b/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
@@ -1,40 +1,34 @@
 package net.imglib2.labkit.plugin.ui;
 
-import com.jgoodies.forms.builder.PanelBuilder;
-import com.jgoodies.forms.layout.CellConstraints;
-import com.jgoodies.forms.layout.FormLayout;
-import ij.gui.GenericDialog;
 import loci.formats.ImageReader;
 import loci.formats.gui.BufferedImageReader;
 import loci.plugins.in.ThumbLoader;
-import loci.plugins.util.WindowTools;
+import net.miginfocom.swing.MigLayout;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SectionsDialog extends GenericDialog
-        implements ActionListener {
+public class SectionsDialog extends JDialog {
 
   private BufferedImageReader thumbReader;
-  private List<Panel> p;
   private List<JRadioButton> boxes;
-  private List<JLabel> sizes;
   private List<Integer> sectionIndices;
   private final ButtonGroup buttonGroup;
-  private ImageReader reader;
 
-  private final int seriesCount;
+  private int seriesCount;
   private Integer selectedSection = null;
 
-  private Button okay;
+  private JOptionPane optionPane;
 
-  public SectionsDialog(ImageReader reader) {
-    super("Select a section");
-    this.reader = reader;
+  public SectionsDialog(ImageReader reader, String filename) {
+    setTitle("Select a section");
+
+    setModal(true);
 
     seriesCount = reader.getSeriesCount();
 
@@ -43,71 +37,87 @@ public class SectionsDialog extends GenericDialog
     // construct thumbnail reader
     thumbReader = new BufferedImageReader(reader);
 
-    int sectionCount = 0;
-    p = new ArrayList<>();
-    boxes = new ArrayList<>();
-    sizes = new ArrayList<>();
-    sectionIndices = new ArrayList<>();
+    sectionIndices = computeSectionIndices();
+
+    //Handle window closing correctly.
+    setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+    addWindowListener(new WindowAdapter() {
+      public void windowClosing(WindowEvent we) {
+        /*
+         * Instead of directly closing the window,
+         * we're going to change the JOptionPane's
+         * value property.
+         */
+        optionPane.setValue(new Integer(
+                JOptionPane.CLOSED_OPTION));
+      }
+    });
+
+    setContentPane(createOptionPane());
+    JScrollPane scrollPane = new JScrollPane(createSections(filename));
+    getContentPane().add(scrollPane, 0);
+
+  }
+
+  private List<Integer> computeSectionIndices() {
+    ArrayList<Integer> indices = new ArrayList<>();
     int lastWidth = -1;
     int lastHeight = -1;
     for (int i = 0; i < seriesCount; i++) {
       thumbReader.setSeries(i);
+      if(thumbReader.isThumbnailSeries()) {
+        seriesCount = i;
+        break;
+      }
       int width = thumbReader.getSizeX();
-      int height = thumbReader.getSizeX();
-      if(lastWidth < 0){
-        //first section
-        sectionCount++;
-        Panel panel = new Panel();
-        p.add(panel);
-        JRadioButton button = new JRadioButton(String.valueOf(sectionCount));
-        boxes.add(button);
-        buttonGroup.add(button);
-        sizes.add(new JLabel(width + " x " + height));
-        sectionIndices.add(i);
-      } else {
-        if(Math.abs(width - lastWidth/2) < 2 && Math.abs(height - lastHeight/2) < 2 ) {
-          //same section
-          JLabel label = sizes.get(sizes.size()-1);
-          label.setText(label.getText() + "\n" + height + " x " + height);
-        } else {
-          //load last sections thumbnail (smallest one should be the last)
-          Panel lastPanel = p.get(p.size()-1);
-          int sx = thumbReader.getThumbSizeX() + 10; // a little extra padding
-          int sy = thumbReader.getThumbSizeY();
-          lastPanel.add(Box.createRigidArea(new Dimension(sx, sy)));
-          ThumbLoader.loadThumb(thumbReader, i-1, lastPanel, true);
-          //create new section
-          sectionCount++;
-          Panel panel = new Panel();
-          p.add(panel);
-          JRadioButton button = new JRadioButton(String.valueOf(sectionCount));
-          boxes.add(button);
-          buttonGroup.add(button);
-          sizes.add(new JLabel(width + " x " + height));
-          sectionIndices.add(i);
-        }
+      int height = thumbReader.getSizeY();
+      if(lastWidth < 0 || Math.abs(width - lastWidth/2) > 2 || Math.abs(height - lastHeight/2) > 2){
+        indices.add(i);
       }
       lastWidth = width;
       lastHeight = height;
     }
-    if(seriesCount > 0) {
-      Panel lastPanel = p.get(p.size()-1);
-      int sx = thumbReader.getThumbSizeX() + 10; // a little extra padding
-      int sy = thumbReader.getThumbSizeY();
-      lastPanel.add(Box.createRigidArea(new Dimension(sx, sy)));
-      ThumbLoader.loadThumb(thumbReader, seriesCount-1, lastPanel, true);
-    }
-
-    addSections();
-
-    okay = new Button("ok");
-    okay.addActionListener(this);
-    okay.addKeyListener(this);
-    add(okay);
+    return indices;
   }
 
+  private Container createOptionPane() {
+    //Create the JOptionPane.
+    optionPane = new JOptionPane("",
+            JOptionPane.PLAIN_MESSAGE,
+            JOptionPane.OK_CANCEL_OPTION,
+            null);
+
+    optionPane.addPropertyChangeListener( e -> {
+      String prop = e.getPropertyName();
+
+      if (isVisible() && (e.getSource() == optionPane) && (JOptionPane.VALUE_PROPERTY.equals(prop))) {
+        if(e.getNewValue().equals(JOptionPane.OK_OPTION)) {
+          for(int i = 0; i < boxes.size(); i++){
+            if(boxes.get(i).isSelected()){
+              selectedSection = i;
+              System.out.println("selected section: " + i);
+              dispose();
+              setVisible(false);
+              return;
+            }
+          }
+
+//          JOptionPane.showMessageDialog(this,
+//                  "Please select a section",
+//                  "No selection warning",
+//                  JOptionPane.WARNING_MESSAGE);
+        }
+        if(e.getNewValue().equals(JOptionPane.CANCEL_OPTION)) {
+          setVisible(false);
+        }
+      }
+    });
+    return optionPane;
+  }
+
+  //!important starts with 1
   public Integer getSelectedSection() {
-    return selectedSection;
+    return selectedSection+1;
   }
 
   public int[] getSelectedSectionIndices() {
@@ -129,60 +139,71 @@ public class SectionsDialog extends GenericDialog
 
   }
 
-  @Override
-  public void actionPerformed(ActionEvent e) {
-    final String cmd = e.getActionCommand();
-    Object source = e.getSource();
-    if(source.equals(okay)){
-      for(int i = 0; i < boxes.size(); i++){
-        if(boxes.get(i).isSelected()){
-          selectedSection = i;
-          System.out.println("selected section: " + i);
-          dispose();
-          return;
-        }
-      }
-    }
-  }
+  public Panel createSections(String filename) {
 
-  public void addSections() {
-    // rebuild dialog to organize things more nicely
+    Panel panel = new Panel();
+    panel.setLayout(new MigLayout("","[]20[][]", ""));
 
-    final String cols = p == null ? "pref" : "pref, 3dlu, pref";
+    panel.add(new JLabel("Please select a section. You can choose the resolution in the next step."), "grow, span,wrap");
 
-    final StringBuilder sb = new StringBuilder("pref");
-    for (int s = 1; s < seriesCount; s++) sb.append(", 3dlu, pref");
-    final String rows = sb.toString();
+    boxes = new ArrayList<>();
 
-    final PanelBuilder builder = new PanelBuilder(new FormLayout(cols, rows));
-    final CellConstraints cc = new CellConstraints();
-
-    int row = 1;
-    for (int s = 0; s < boxes.size(); s++) {
-      builder.add(boxes.get(s), cc.xy(1, row));
-      builder.add(sizes.get(s), cc.xy(1, row));
-      if (p != null) builder.add(p.get(s), cc.xy(3, row));
-      row += 2;
+    for(int i = 0; i < sectionIndices.size(); i++){
+      panel.add(line(), "grow, span, wrap");
+      panel.add(sectionRadioButton(i));
+      panel.add(descriptiveLabel(filename, i), "grow,push");
+      panel.add(thumbPanel(thumbnailIndex(i)), "wrap");
     }
 
-    final JPanel masterPanel = builder.getPanel();
-
-    removeAll();
-
-    GridBagLayout gdl = (GridBagLayout) getLayout();
-    GridBagConstraints gbc = new GridBagConstraints();
-    gbc.gridx = 0;
-    gbc.gridy = 0;
-    gdl.setConstraints(masterPanel, gbc);
-
-    add(masterPanel);
-
-    WindowTools.addScrollBars(this);
-    setBackground(Color.white); // HACK: workaround for JPanel in a Dialog
+    return panel;
 
   }
 
+  private int thumbnailIndex(int i) {
+    return i+1 < sectionIndices.size() ? sectionIndices.get(i+1)-1 : seriesCount-1;
+  }
+
+  private Component thumbPanel(int index) {
+    int sx = thumbReader.getThumbSizeX() + 10; // a little extra padding
+    int sy = thumbReader.getThumbSizeY();
+    Panel thumbPanel = new Panel();
+    ThumbLoader.loadThumb(thumbReader, index, thumbPanel, false);
+    return thumbPanel;
+  }
+
+  private Component descriptiveLabel(String filename, int i) {
+    JLabel label = new JLabel();
+    Font font = label.getFont();
+    label.setFont(font.deriveFont(font.getStyle() & ~Font.BOLD));
+    int sectionIndex = sectionIndices.get(i);
+    int lastIndex = i+1 < sectionIndices.size() ? sectionIndices.get(i+1) : seriesCount;
+    String labelText = "<html>";
+    if(labelingExists(filename, i)) {
+      labelText += "<b>[existing labeling found]</b><br />";
+    }
+    labelText += "<font face=\"verdana\">";
+    for(int j = sectionIndex; j < lastIndex; j++) {
+      thumbReader.setSeries(j);
+      labelText += thumbReader.getSizeX() + " x " + thumbReader.getSizeY() + "<br/>";
+    }
+    label.setText(labelText);
+    return label;
+  }
+
+  private Component sectionRadioButton(int i) {
+    JRadioButton button = new JRadioButton(String.valueOf(i+1));
+    buttonGroup.add(button);
+    boxes.add(button);
+    return button;
+  }
+
+  private boolean labelingExists(String filename, int i) {
+    return new File(filename.replace(".czi", "") + "-" + (i+1) + ".czi.labeling").exists();
+  }
+
+  private Component line() {
+    JPanel line = new JPanel();
+    line.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.lightGray));
+    return line;
+  }
 }
-
-
-

--- a/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
+++ b/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
@@ -15,195 +15,195 @@ import java.util.List;
 
 public class SectionsDialog extends JDialog {
 
-  private BufferedImageReader thumbReader;
-  private List<JRadioButton> boxes;
-  private List<Integer> sectionIndices;
-  private final ButtonGroup buttonGroup;
+	private BufferedImageReader thumbReader;
+	private List<JRadioButton> boxes;
+	private List<Integer> sectionIndices;
+	private final ButtonGroup buttonGroup;
 
-  private int seriesCount;
-  private Integer selectedSection = null;
+	private int seriesCount;
+	private Integer selectedSection = null;
 
-  private JOptionPane optionPane;
+	private JOptionPane optionPane;
 
-  public SectionsDialog(ImageReader reader, String filename) {
-    setTitle("Select a section");
+	public SectionsDialog(ImageReader reader, String filename) {
+		setTitle("Select a section");
 
-    setModal(true);
+		setModal(true);
 
-    seriesCount = reader.getSeriesCount();
+		seriesCount = reader.getSeriesCount();
 
-    buttonGroup = new ButtonGroup();
+		buttonGroup = new ButtonGroup();
 
-    // construct thumbnail reader
-    thumbReader = new BufferedImageReader(reader);
+		// construct thumbnail reader
+		thumbReader = new BufferedImageReader(reader);
 
-    sectionIndices = computeSectionIndices();
+		sectionIndices = computeSectionIndices();
 
-    //Handle window closing correctly.
-    setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
-    addWindowListener(new WindowAdapter() {
-      public void windowClosing(WindowEvent we) {
-        /*
+		//Handle window closing correctly.
+		setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+		addWindowListener(new WindowAdapter() {
+			public void windowClosing(WindowEvent we) {
+		/*
          * Instead of directly closing the window,
          * we're going to change the JOptionPane's
          * value property.
          */
-        optionPane.setValue(new Integer(
-                JOptionPane.CLOSED_OPTION));
-      }
-    });
+				optionPane.setValue(new Integer(
+						JOptionPane.CLOSED_OPTION));
+			}
+		});
 
-    setContentPane(createOptionPane());
-    JScrollPane scrollPane = new JScrollPane(createSections(filename));
-    getContentPane().add(scrollPane, 0);
+		setContentPane(createOptionPane());
+		JScrollPane scrollPane = new JScrollPane(createSections(filename));
+		getContentPane().add(scrollPane, 0);
 
-  }
+	}
 
-  private List<Integer> computeSectionIndices() {
-    ArrayList<Integer> indices = new ArrayList<>();
-    int lastWidth = -1;
-    int lastHeight = -1;
-    for (int i = 0; i < seriesCount; i++) {
-      thumbReader.setSeries(i);
-      if(thumbReader.isThumbnailSeries()) {
-        seriesCount = i;
-        break;
-      }
-      int width = thumbReader.getSizeX();
-      int height = thumbReader.getSizeY();
-      if(lastWidth < 0 || Math.abs(width - lastWidth/2) > 2 || Math.abs(height - lastHeight/2) > 2){
-        indices.add(i);
-      }
-      lastWidth = width;
-      lastHeight = height;
-    }
-    return indices;
-  }
+	private List<Integer> computeSectionIndices() {
+		ArrayList<Integer> indices = new ArrayList<>();
+		int lastWidth = -1;
+		int lastHeight = -1;
+		for (int i = 0; i < seriesCount; i++) {
+			thumbReader.setSeries(i);
+			if (thumbReader.isThumbnailSeries()) {
+				seriesCount = i;
+				break;
+			}
+			int width = thumbReader.getSizeX();
+			int height = thumbReader.getSizeY();
+			if (lastWidth < 0 || Math.abs(width - lastWidth / 2) > 2 || Math.abs(height - lastHeight / 2) > 2) {
+				indices.add(i);
+			}
+			lastWidth = width;
+			lastHeight = height;
+		}
+		return indices;
+	}
 
-  private Container createOptionPane() {
-    //Create the JOptionPane.
-    optionPane = new JOptionPane("",
-            JOptionPane.PLAIN_MESSAGE,
-            JOptionPane.OK_CANCEL_OPTION,
-            null);
+	private Container createOptionPane() {
+		//Create the JOptionPane.
+		optionPane = new JOptionPane("",
+				JOptionPane.PLAIN_MESSAGE,
+				JOptionPane.OK_CANCEL_OPTION,
+				null);
 
-    optionPane.addPropertyChangeListener( e -> {
-      String prop = e.getPropertyName();
+		optionPane.addPropertyChangeListener(e -> {
+			String prop = e.getPropertyName();
 
-      if (isVisible() && (e.getSource() == optionPane) && (JOptionPane.VALUE_PROPERTY.equals(prop))) {
-        if(e.getNewValue().equals(JOptionPane.OK_OPTION)) {
-          for(int i = 0; i < boxes.size(); i++){
-            if(boxes.get(i).isSelected()){
-              selectedSection = i;
-              System.out.println("selected section: " + i);
-              dispose();
-              setVisible(false);
-              return;
-            }
-          }
+			if (isVisible() && (e.getSource() == optionPane) && (JOptionPane.VALUE_PROPERTY.equals(prop))) {
+				if (e.getNewValue().equals(JOptionPane.OK_OPTION)) {
+					for (int i = 0; i < boxes.size(); i++) {
+						if (boxes.get(i).isSelected()) {
+							selectedSection = i;
+							System.out.println("selected section: " + i);
+							dispose();
+							setVisible(false);
+							return;
+						}
+					}
 
 //          JOptionPane.showMessageDialog(this,
 //                  "Please select a section",
 //                  "No selection warning",
 //                  JOptionPane.WARNING_MESSAGE);
-        }
-        if(e.getNewValue().equals(JOptionPane.CANCEL_OPTION)) {
-          setVisible(false);
-        }
-      }
-    });
-    return optionPane;
-  }
+				}
+				if (e.getNewValue().equals(JOptionPane.CANCEL_OPTION)) {
+					setVisible(false);
+				}
+			}
+		});
+		return optionPane;
+	}
 
-  //!important starts with 1
-  public Integer getSelectedSection() {
-    return selectedSection+1;
-  }
+	//!important starts with 1
+	public Integer getSelectedSection() {
+		return selectedSection + 1;
+	}
 
-  public int[] getSelectedSectionIndices() {
+	public int[] getSelectedSectionIndices() {
 
-    int firstIndex = sectionIndices.get(selectedSection);
-    int lastIndex;
-    if(sectionIndices.size() > selectedSection+1) {
-      lastIndex = sectionIndices.get(selectedSection+1)-1;
-    }else {
-      lastIndex = seriesCount-1;
-    }
+		int firstIndex = sectionIndices.get(selectedSection);
+		int lastIndex;
+		if (sectionIndices.size() > selectedSection + 1) {
+			lastIndex = sectionIndices.get(selectedSection + 1) - 1;
+		} else {
+			lastIndex = seriesCount - 1;
+		}
 
-    int[] res = new int[lastIndex-firstIndex+1];
-    for(int i = firstIndex; i <= lastIndex; i++) {
-      res[i-firstIndex] = i;
-    }
+		int[] res = new int[lastIndex - firstIndex + 1];
+		for (int i = firstIndex; i <= lastIndex; i++) {
+			res[i - firstIndex] = i;
+		}
 
-    return res;
+		return res;
 
-  }
+	}
 
-  public Panel createSections(String filename) {
+	public Panel createSections(String filename) {
 
-    Panel panel = new Panel();
-    panel.setLayout(new MigLayout("","[]20[][]", ""));
+		Panel panel = new Panel();
+		panel.setLayout(new MigLayout("", "[]20[][]", ""));
 
-    panel.add(new JLabel("Please select a section. You can choose the resolution in the next step."), "grow, span,wrap");
+		panel.add(new JLabel("Please select a section. You can choose the resolution in the next step."), "grow, span,wrap");
 
-    boxes = new ArrayList<>();
+		boxes = new ArrayList<>();
 
-    for(int i = 0; i < sectionIndices.size(); i++){
-      panel.add(line(), "grow, span, wrap");
-      panel.add(sectionRadioButton(i));
-      panel.add(descriptiveLabel(filename, i), "grow,push");
-      panel.add(thumbPanel(thumbnailIndex(i)), "wrap");
-    }
+		for (int i = 0; i < sectionIndices.size(); i++) {
+			panel.add(line(), "grow, span, wrap");
+			panel.add(sectionRadioButton(i));
+			panel.add(descriptiveLabel(filename, i), "grow,push");
+			panel.add(thumbPanel(thumbnailIndex(i)), "wrap");
+		}
 
-    return panel;
+		return panel;
 
-  }
+	}
 
-  private int thumbnailIndex(int i) {
-    return i+1 < sectionIndices.size() ? sectionIndices.get(i+1)-1 : seriesCount-1;
-  }
+	private int thumbnailIndex(int i) {
+		return i + 1 < sectionIndices.size() ? sectionIndices.get(i + 1) - 1 : seriesCount - 1;
+	}
 
-  private Component thumbPanel(int index) {
-    int sx = thumbReader.getThumbSizeX() + 10; // a little extra padding
-    int sy = thumbReader.getThumbSizeY();
-    Panel thumbPanel = new Panel();
-    ThumbLoader.loadThumb(thumbReader, index, thumbPanel, false);
-    return thumbPanel;
-  }
+	private Component thumbPanel(int index) {
+		int sx = thumbReader.getThumbSizeX() + 10; // a little extra padding
+		int sy = thumbReader.getThumbSizeY();
+		Panel thumbPanel = new Panel();
+		ThumbLoader.loadThumb(thumbReader, index, thumbPanel, false);
+		return thumbPanel;
+	}
 
-  private Component descriptiveLabel(String filename, int i) {
-    JLabel label = new JLabel();
-    Font font = label.getFont();
-    label.setFont(font.deriveFont(font.getStyle() & ~Font.BOLD));
-    int sectionIndex = sectionIndices.get(i);
-    int lastIndex = i+1 < sectionIndices.size() ? sectionIndices.get(i+1) : seriesCount;
-    String labelText = "<html>";
-    if(labelingExists(filename, i)) {
-      labelText += "<b>[existing labeling found]</b><br />";
-    }
-    labelText += "<font face=\"verdana\">";
-    for(int j = sectionIndex; j < lastIndex; j++) {
-      thumbReader.setSeries(j);
-      labelText += thumbReader.getSizeX() + " x " + thumbReader.getSizeY() + "<br/>";
-    }
-    label.setText(labelText);
-    return label;
-  }
+	private Component descriptiveLabel(String filename, int i) {
+		JLabel label = new JLabel();
+		Font font = label.getFont();
+		label.setFont(font.deriveFont(font.getStyle() & ~Font.BOLD));
+		int sectionIndex = sectionIndices.get(i);
+		int lastIndex = i + 1 < sectionIndices.size() ? sectionIndices.get(i + 1) : seriesCount;
+		String labelText = "<html>";
+		if (labelingExists(filename, i)) {
+			labelText += "<b>[existing labeling found]</b><br />";
+		}
+		labelText += "<font face=\"verdana\">";
+		for (int j = sectionIndex; j < lastIndex; j++) {
+			thumbReader.setSeries(j);
+			labelText += thumbReader.getSizeX() + " x " + thumbReader.getSizeY() + "<br/>";
+		}
+		label.setText(labelText);
+		return label;
+	}
 
-  private Component sectionRadioButton(int i) {
-    JRadioButton button = new JRadioButton(String.valueOf(i+1));
-    buttonGroup.add(button);
-    boxes.add(button);
-    return button;
-  }
+	private Component sectionRadioButton(int i) {
+		JRadioButton button = new JRadioButton(String.valueOf(i + 1));
+		buttonGroup.add(button);
+		boxes.add(button);
+		return button;
+	}
 
-  private boolean labelingExists(String filename, int i) {
-    return new File(filename.replace(".czi", "") + "-" + (i+1) + ".czi.labeling").exists();
-  }
+	private boolean labelingExists(String filename, int i) {
+		return new File(filename.replace(".czi", "") + "-" + (i + 1) + ".czi.labeling").exists();
+	}
 
-  private Component line() {
-    JPanel line = new JPanel();
-    line.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.lightGray));
-    return line;
-  }
+	private Component line() {
+		JPanel line = new JPanel();
+		line.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.lightGray));
+		return line;
+	}
 }

--- a/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
+++ b/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
@@ -1,0 +1,188 @@
+package net.imglib2.labkit.plugin.ui;
+
+import com.jgoodies.forms.builder.PanelBuilder;
+import com.jgoodies.forms.layout.CellConstraints;
+import com.jgoodies.forms.layout.FormLayout;
+import ij.gui.GenericDialog;
+import loci.formats.ImageReader;
+import loci.formats.gui.BufferedImageReader;
+import loci.plugins.in.ThumbLoader;
+import loci.plugins.util.WindowTools;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SectionsDialog extends GenericDialog
+        implements ActionListener {
+
+  private BufferedImageReader thumbReader;
+  private List<Panel> p;
+  private List<JRadioButton> boxes;
+  private List<JLabel> sizes;
+  private List<Integer> sectionIndices;
+  private final ButtonGroup buttonGroup;
+  private ImageReader reader;
+
+  private final int seriesCount;
+  private Integer selectedSection = null;
+
+  private Button okay;
+
+  public SectionsDialog(ImageReader reader) {
+    super("Select a section");
+    this.reader = reader;
+
+    seriesCount = reader.getSeriesCount();
+
+    buttonGroup = new ButtonGroup();
+
+    // construct thumbnail reader
+    thumbReader = new BufferedImageReader(reader);
+
+    int sectionCount = 0;
+    p = new ArrayList<>();
+    boxes = new ArrayList<>();
+    sizes = new ArrayList<>();
+    sectionIndices = new ArrayList<>();
+    int lastWidth = -1;
+    int lastHeight = -1;
+    for (int i = 0; i < seriesCount; i++) {
+      thumbReader.setSeries(i);
+      int width = thumbReader.getSizeX();
+      int height = thumbReader.getSizeX();
+      if(lastWidth < 0){
+        //first section
+        sectionCount++;
+        Panel panel = new Panel();
+        p.add(panel);
+        JRadioButton button = new JRadioButton(String.valueOf(sectionCount));
+        boxes.add(button);
+        buttonGroup.add(button);
+        sizes.add(new JLabel(width + " x " + height));
+        sectionIndices.add(i);
+      } else {
+        if(Math.abs(width - lastWidth/2) < 2 && Math.abs(height - lastHeight/2) < 2 ) {
+          //same section
+          JLabel label = sizes.get(sizes.size()-1);
+          label.setText(label.getText() + "\n" + height + " x " + height);
+        } else {
+          //load last sections thumbnail (smallest one should be the last)
+          Panel lastPanel = p.get(p.size()-1);
+          int sx = thumbReader.getThumbSizeX() + 10; // a little extra padding
+          int sy = thumbReader.getThumbSizeY();
+          lastPanel.add(Box.createRigidArea(new Dimension(sx, sy)));
+          ThumbLoader.loadThumb(thumbReader, i-1, lastPanel, true);
+          //create new section
+          sectionCount++;
+          Panel panel = new Panel();
+          p.add(panel);
+          JRadioButton button = new JRadioButton(String.valueOf(sectionCount));
+          boxes.add(button);
+          buttonGroup.add(button);
+          sizes.add(new JLabel(width + " x " + height));
+          sectionIndices.add(i);
+        }
+      }
+      lastWidth = width;
+      lastHeight = height;
+    }
+    if(seriesCount > 0) {
+      Panel lastPanel = p.get(p.size()-1);
+      int sx = thumbReader.getThumbSizeX() + 10; // a little extra padding
+      int sy = thumbReader.getThumbSizeY();
+      lastPanel.add(Box.createRigidArea(new Dimension(sx, sy)));
+      ThumbLoader.loadThumb(thumbReader, seriesCount-1, lastPanel, true);
+    }
+
+    addSections();
+
+    okay = new Button("ok");
+    okay.addActionListener(this);
+    okay.addKeyListener(this);
+    add(okay);
+  }
+
+  public Integer getSelectedSection() {
+    return selectedSection;
+  }
+
+  public int[] getSelectedSectionIndices() {
+
+    int firstIndex = sectionIndices.get(selectedSection);
+    int lastIndex;
+    if(sectionIndices.size() > selectedSection+1) {
+      lastIndex = sectionIndices.get(selectedSection+1)-1;
+    }else {
+      lastIndex = seriesCount-1;
+    }
+
+    int[] res = new int[lastIndex-firstIndex+1];
+    for(int i = firstIndex; i <= lastIndex; i++) {
+      res[i-firstIndex] = i;
+    }
+
+    return res;
+
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    final String cmd = e.getActionCommand();
+    Object source = e.getSource();
+    if(source.equals(okay)){
+      for(int i = 0; i < boxes.size(); i++){
+        if(boxes.get(i).isSelected()){
+          selectedSection = i;
+          System.out.println("selected section: " + i);
+          dispose();
+          return;
+        }
+      }
+    }
+  }
+
+  public void addSections() {
+    // rebuild dialog to organize things more nicely
+
+    final String cols = p == null ? "pref" : "pref, 3dlu, pref";
+
+    final StringBuilder sb = new StringBuilder("pref");
+    for (int s = 1; s < seriesCount; s++) sb.append(", 3dlu, pref");
+    final String rows = sb.toString();
+
+    final PanelBuilder builder = new PanelBuilder(new FormLayout(cols, rows));
+    final CellConstraints cc = new CellConstraints();
+
+    int row = 1;
+    for (int s = 0; s < boxes.size(); s++) {
+      builder.add(boxes.get(s), cc.xy(1, row));
+      builder.add(sizes.get(s), cc.xy(1, row));
+      if (p != null) builder.add(p.get(s), cc.xy(3, row));
+      row += 2;
+    }
+
+    final JPanel masterPanel = builder.getPanel();
+
+    removeAll();
+
+    GridBagLayout gdl = (GridBagLayout) getLayout();
+    GridBagConstraints gbc = new GridBagConstraints();
+    gbc.gridx = 0;
+    gbc.gridy = 0;
+    gdl.setConstraints(masterPanel, gbc);
+
+    add(masterPanel);
+
+    WindowTools.addScrollBars(this);
+    setBackground(Color.white); // HACK: workaround for JPanel in a Dialog
+
+  }
+
+}
+
+
+

--- a/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
+++ b/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
@@ -107,9 +107,8 @@ public class SectionsDialog extends JDialog {
 		return optionPane;
 	}
 
-	//!important starts with 1
 	public Integer getSelectedSection() {
-		return selectedSection + 1;
+		return selectedSection;
 	}
 
 	public int[] getSelectedSectionIndices() {

--- a/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
+++ b/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
@@ -21,10 +21,7 @@ public class SectionsDialog extends JDialog {
 		dialog.pack();
 		dialog.setLocationRelativeTo(null);
 		dialog.setVisible(true);
-		int[] sectionIds = dialog.getSelectedSectionIndices();
-		if(sectionIds == null) {
-			throw new CancellationException();
-		}
+		if(dialog.wasCancelled()) throw new CancellationException();
 		return dialog;
 	}
 
@@ -127,6 +124,10 @@ public class SectionsDialog extends JDialog {
 	public int[] getSelectedSectionIndices() {
 		// TODO use list instead
 		return sectionIndices.get(selectedSection).stream().mapToInt(i -> i).toArray();
+	}
+
+	private boolean wasCancelled() {
+		return selectedSection == null;
 	}
 
 	public Panel createSections(String filename) {

--- a/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
+++ b/src/main/java/net/imglib2/labkit/plugin/ui/SectionsDialog.java
@@ -93,7 +93,6 @@ public class SectionsDialog extends JDialog {
 					for (int i = 0; i < boxes.size(); i++) {
 						if (boxes.get(i).isSelected()) {
 							selectedSection = i;
-							System.out.println("selected section: " + i);
 							dispose();
 							setVisible(false);
 							return;

--- a/src/test/java/net/imglib2/labkit/CZIImportDemo.java
+++ b/src/test/java/net/imglib2/labkit/CZIImportDemo.java
@@ -1,0 +1,23 @@
+package net.imglib2.labkit;
+
+import net.imagej.ImageJ;
+import net.imglib2.labkit.plugin.LabkitImportPlugin;
+import net.imglib2.labkit.plugin.LabkitPlugin;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Created by random on 13.03.18.
+ */
+public class CZIImportDemo {
+
+    public static void main(String... args) throws IOException {
+        ImageJ imageJ = new ImageJ();
+        imageJ.ui().showUI();
+        String filename = "/home/random/Development/imagej/project/labkit/data/Lung Images/2017_11_30__0034.czi";
+        File file = new File(filename);
+
+        imageJ.command().run(LabkitImportPlugin.class, true, "file", file);
+    }
+}

--- a/src/test/java/net/imglib2/labkit/GarbageCollectionTest.java
+++ b/src/test/java/net/imglib2/labkit/GarbageCollectionTest.java
@@ -1,0 +1,126 @@
+package net.imglib2.labkit;
+
+import bdv.util.Bdv;
+import bdv.util.BdvFunctions;
+import bdv.util.BdvHandle;
+import bdv.util.BdvHandlePanel;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.ByteType;
+import org.junit.Test;
+import org.scijava.Context;
+
+import javax.swing.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class GarbageCollectionTest
+{
+
+	private final Context context = new Context();
+
+	@Test
+	public void testButton() throws InterruptedException
+	{
+		showAndCloseManyJFrames( this::addButton );
+	}
+
+	// NB: Bdv seems to keep the JFrames from being garbage collected.
+	@Test
+	public void testBdv() throws InterruptedException
+	{
+		showAndCloseManyJFrames( this::addBigDataViewer );
+	}
+
+	@Test
+	public void testSegmentationComponent() throws InterruptedException
+	{
+		showAndCloseManyJFrames( this::addSegmentationComponent );
+	}
+
+	private void showAndCloseManyJFrames( Consumer< JFrame > componentAdder ) throws InterruptedException
+	{
+		int n = 5;
+		for ( int i = 0; i < n; i++ )
+		{
+			System.out.println( "Step " + i + " of " + n );
+			showAndCloseJFrames( componentAdder );
+		}
+	}
+
+	private void showAndCloseJFrames( Consumer< JFrame > componentAdder ) throws InterruptedException
+	{
+		List<JFrame> frames = new ArrayList<>();
+		for ( int i = 0; i < 3; i++ )
+			frames.add( showJFrame( componentAdder ) );
+		Thread.sleep( 1000 );
+		for ( JFrame frame : frames )
+			closeJFrame(frame);
+	}
+
+	private JFrame showJFrame( Consumer< JFrame > componentAdder )
+	{
+		JFrame frame = new JFrame() {
+			private byte[] data = allocateMemory();
+		};
+		frame.setDefaultCloseOperation( JFrame.DISPOSE_ON_CLOSE );
+		frame.setSize(500,500);
+		componentAdder.accept( frame );
+		frame.setVisible( true );
+		return frame;
+	}
+
+	private byte[] allocateMemory()
+	{
+		return new byte[ boundedConvertToInt( Runtime.getRuntime().maxMemory() / 10 ) ];
+	}
+
+	private void closeJFrame( JFrame frame )
+	{
+		frame.dispatchEvent(new WindowEvent(frame, WindowEvent.WINDOW_CLOSING));
+	}
+
+	private void addBigDataViewer( JFrame frame )
+	{
+		BdvHandle handle = new BdvHandlePanel( frame, Bdv.options() );
+		BdvFunctions.show( createaImage(), "Image", Bdv.options().addTo( handle ));
+		frame.add(handle.getViewerPanel());
+		frame.addWindowListener( new WindowAdapter()
+		{
+			@Override public void windowClosed( WindowEvent e )
+			{
+				handle.close();
+			}
+		} );
+	}
+
+	private void addSegmentationComponent( JFrame frame ) {
+		SegmentationComponent component = new SegmentationComponent( context, frame, createaImage(), false );
+		frame.add(component.getComponent());
+		frame.addWindowListener( new WindowAdapter()
+		{
+			@Override public void windowClosed( WindowEvent e )
+			{
+				component.close();
+			}
+		} );
+	}
+
+	private RandomAccessibleInterval< ByteType > createaImage()
+	{
+		return ArrayImgs.bytes( 10, 10 );
+	}
+
+	private void addButton( JFrame frame )
+	{
+		frame.add(new JButton("Hello World!"));
+	}
+
+	private int boundedConvertToInt( long dataSize )
+	{
+		return ( int ) Math.max( Integer.MIN_VALUE, Math.min( Integer.MAX_VALUE, dataSize ) );
+	}
+}


### PR DESCRIPTION
This PR adds support for multiple sections in one CZI file. 
Example (list image series resolutions in CZI with marked sections):
```
15998 x 10894 // first section
7999 x 5447
3999 x 2723
1999 x 1361
999 x 680
20321 x 8758 // second section
10160 x 4379
5080 x 2189
2540 x 1094
1270 x 547
635 x 273
14569 x 10897 // third section
7284 x 5448
3642 x 2724
1821 x 1362
910 x 681
720 x 578 // label image
1580 x 748 // macro image
```

Steps:
- Open CZI file via Plugins > Segmentation > Labkit (CZI / experimental)
- Choose section (this is the new Dialog)
- Choose resolution of section (this will be replaced with resolution pyramid loading later)

According to the index of the section (starting with 1), the fitting labeling file will be loaded:
image data: `myfile.czi`
labeling file for section 1: `myfile-1.czi.labeling`
labeling file for section 2: `myfile-2.czi.labeling`

Currently the labeling is only scaled correctly if one opens the section in the highest resolution.

