### PR TITLE
Use imglib2 Cast.unchecked()

### DIFF
--- a/src/main/java/net/imglib2/labkit/actions/LabelingIoAction.java
+++ b/src/main/java/net/imglib2/labkit/actions/LabelingIoAction.java
@@ -5,11 +5,11 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.labkit.Extensible;
 import net.imglib2.labkit.MenuBar;
 import net.imglib2.labkit.models.LabelingModel;
-import net.imglib2.labkit.utils.LabkitUtils;
 import net.imglib2.labkit.labeling.Labeling;
 import net.imglib2.labkit.labeling.LabelingSerializer;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.util.Cast;
 
 import java.io.IOException;
 
@@ -53,7 +53,7 @@ public class LabelingIoAction extends AbstractFileIoAction {
 	private void showLabelingInImageJ() {
 		RandomAccessibleInterval<? extends IntegerType<?>> img = labelingModel
 			.labeling().get().getIndexImg();
-		ImageJFunctions.show(LabkitUtils.uncheckedCast(img), "Labeling");
+		ImageJFunctions.show(Cast.unchecked(img), "Labeling");
 	}
 
 	private void open(Void ignore, String filename) throws IOException {

--- a/src/main/java/net/imglib2/labkit/labeling/Labeling.java
+++ b/src/main/java/net/imglib2/labkit/labeling/Labeling.java
@@ -2,13 +2,11 @@
 package net.imglib2.labkit.labeling;
 
 import com.google.gson.annotations.JsonAdapter;
-import com.google.gson.internal.LinkedTreeMap;
 import net.imagej.axis.CalibratedAxis;
 import net.imagej.axis.DefaultLinearAxis;
 import net.imglib2.*;
 import net.imglib2.RandomAccess;
 import net.imglib2.labkit.utils.ColorSupplier;
-import net.imglib2.labkit.utils.LabkitUtils;
 import net.imglib2.converter.Converter;
 import net.imglib2.converter.Converters;
 import net.imglib2.loops.LoopBuilder;
@@ -22,6 +20,7 @@ import net.imglib2.type.BooleanType;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.util.Cast;
 import net.imglib2.util.ConstantUtils;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
@@ -285,11 +284,11 @@ public class Labeling extends AbstractWrappedInterval<Interval> implements
 
 	@Override
 	public RandomAccess<LabelingType<Label>> randomAccess() {
-		return LabkitUtils.uncheckedCast(imgLabeling.randomAccess());
+		return Cast.unchecked(imgLabeling.randomAccess());
 	}
 
 	@Override
 	public RandomAccess<LabelingType<Label>> randomAccess(Interval interval) {
-		return LabkitUtils.uncheckedCast(imgLabeling.randomAccess(interval));
+		return Cast.unchecked(imgLabeling.randomAccess(interval));
 	}
 }

--- a/src/main/java/net/imglib2/labkit/labeling/LabelingSerializer.java
+++ b/src/main/java/net/imglib2/labkit/labeling/LabelingSerializer.java
@@ -17,7 +17,6 @@ import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.Point;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.labkit.utils.LabkitUtils;
 import net.imglib2.img.Img;
 import net.imglib2.roi.IterableRegion;
 import net.imglib2.roi.labeling.ImgLabeling;
@@ -27,6 +26,7 @@ import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.util.Cast;
 import org.apache.commons.io.FilenameUtils;
 import org.scijava.Context;
 
@@ -110,8 +110,7 @@ public class LabelingSerializer {
 		RandomAccessibleInterval<? extends IntegerType<?>> img,
 		List<Set<L>> labelSets)
 	{
-		ImgLabeling<L, ?> result = new ImgLabeling<>(LabkitUtils.uncheckedCast(
-			img));
+		ImgLabeling<L, ?> result = new ImgLabeling<>(Cast.unchecked(img));
 		new LabelingMapping.SerialisationAccess<L>(result.getMapping()) {
 
 			public void run() {
@@ -125,7 +124,7 @@ public class LabelingSerializer {
 		throws IOException
 	{
 		DatasetIOService io = context.service(DatasetIOService.class);
-		return LabkitUtils.uncheckedCast(io.open(filename).getImgPlus().getImg());
+		return Cast.unchecked(io.open(filename).getImgPlus().getImg());
 	}
 
 	private LabelsMetaData openMetaData(String filename) throws IOException {
@@ -165,8 +164,7 @@ public class LabelingSerializer {
 		}
 		DatasetIOService io = context.service(DatasetIOService.class);
 		DatasetService ds = context.service(DatasetService.class);
-		RandomAccessibleInterval<I> imgPlus = LabkitUtils.uncheckedCast(labeling
-			.getIndexImg());
+		RandomAccessibleInterval<I> imgPlus = Cast.unchecked(labeling.getIndexImg());
 		io.save(ds.create(imgPlus), filename);
 	}
 

--- a/src/main/java/net/imglib2/labkit/utils/LabkitUtils.java
+++ b/src/main/java/net/imglib2/labkit/utils/LabkitUtils.java
@@ -2,18 +2,13 @@
 package net.imglib2.labkit.utils;
 
 import bdv.export.ProgressWriter;
-import net.imagej.ImgPlus;
-import net.imagej.axis.Axes;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.cache.img.CachedCellImg;
-import net.imglib2.img.cell.CellGrid;
 import net.imglib2.converter.Converters;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
-import net.imglib2.labkit.inputimage.ImgPlusViewsOld;
-import net.imglib2.trainable_segmentation.RevampUtils;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.IntegerType;
@@ -22,6 +17,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Cast;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.Pair;
 import net.imglib2.util.ValuePair;
@@ -52,12 +48,6 @@ public class LabkitUtils {
 		System.arraycopy(array, 0, result, 0, length);
 		result[length] = value;
 		return result;
-	}
-
-	public static <R, T> R uncheckedCast(T value) {
-		@SuppressWarnings("unchecked")
-		R r = (R) value;
-		return r;
 	}
 
 	public static RandomAccessibleInterval<FloatType> toFloat(
@@ -122,8 +112,7 @@ public class LabkitUtils {
 	public static <T> RandomAccessibleInterval<T> populateCachedImg(
 		RandomAccessibleInterval<T> img, ProgressWriter progressWriter)
 	{
-		if (img instanceof CachedCellImg) internPopulateCachedImg(LabkitUtils
-			.uncheckedCast(img), progressWriter);
+		if (img instanceof CachedCellImg) internPopulateCachedImg(Cast.unchecked(img), progressWriter);
 		return img;
 	}
 


### PR DESCRIPTION
Now that Cast.unchecked() is available in imglib2, LabkitUtils.uncheckedCast() can be removed