### PR TITLE
Improve screen resolution during drawing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<jackson-dataformat-yaml.version>2.11.1</jackson-dataformat-yaml.version>
 		<jackson-databind.version>2.11.1</jackson-databind.version>
 
-		<bigdataviewer-core.version>10.0.0</bigdataviewer-core.version>
+		<bigdataviewer-core.version>10.0.1</bigdataviewer-core.version>
 		<bigdataviewer-vistools.version>1.0.0-beta-22</bigdataviewer-vistools.version>
 
 		<imglib2-trainable-segmentation.version>0.1.4</imglib2-trainable-segmentation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,12 +154,6 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-core</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>com.miglayout</groupId>
-					<artifactId>miglayout-swing</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>

--- a/src/main/java/net/imglib2/labkit/bdv/BdvLayer.java
+++ b/src/main/java/net/imglib2/labkit/bdv/BdvLayer.java
@@ -1,8 +1,9 @@
 
 package net.imglib2.labkit.bdv;
 
+import net.imglib2.Interval;
 import net.imglib2.labkit.models.Holder;
-import net.imglib2.labkit.utils.Notifier;
+import net.imglib2.labkit.utils.ParametricNotifier;
 
 /**
  * Objects that implement {@link BdvLayer}, can easily be made visible in
@@ -12,7 +13,7 @@ public interface BdvLayer {
 
 	Holder<BdvShowable> image();
 
-	Notifier listeners();
+	ParametricNotifier<Interval> listeners();
 
 	Holder<Boolean> visibility();
 
@@ -22,7 +23,8 @@ public interface BdvLayer {
 
 		private final Holder<BdvShowable> image;
 		private final String title;
-		private final Notifier listeners = new Notifier();
+		private final ParametricNotifier<Interval> listeners =
+			new ParametricNotifier<>();
 		private final Holder<Boolean> visibility;
 
 		public FinalLayer(Holder<BdvShowable> image, String title,
@@ -39,7 +41,7 @@ public interface BdvLayer {
 		}
 
 		@Override
-		public Notifier listeners() {
+		public ParametricNotifier<Interval> listeners() {
 			return listeners;
 		}
 

--- a/src/main/java/net/imglib2/labkit/bdv/BdvLayerLink.java
+++ b/src/main/java/net/imglib2/labkit/bdv/BdvLayerLink.java
@@ -6,8 +6,11 @@ import bdv.util.BdvOptions;
 import bdv.util.BdvStackSource;
 import bdv.viewer.SynchronizedViewerState;
 import bdv.viewer.ViewerStateChange;
+import net.imglib2.Interval;
 import net.imglib2.labkit.models.Holder;
 import net.imglib2.labkit.utils.Notifier;
+
+import java.util.function.Consumer;
 
 /**
  * BdvLayerLink links a {@link BdvLayer} to a Big Data Viewer
@@ -35,7 +38,7 @@ public class BdvLayerLink implements Holder<BdvStackSource<?>> {
 
 	private final Runnable onVisibilityChanged = this::onVisibilityChanged;
 
-	private final Runnable onRequestRepaint = this::requestRepaint;
+	private final Consumer<Interval> onRequestRepaint = this::onRequestRepaint;
 
 	private BdvStackSource<?> bdvSource;
 
@@ -70,8 +73,11 @@ public class BdvLayerLink implements Holder<BdvStackSource<?>> {
 		notifier.notifyListeners();
 	}
 
-	private void requestRepaint() {
-		handle.getViewerPanel().requestRepaint();
+	private void onRequestRepaint(Interval interval) {
+		if (interval == null)
+			handle.getViewerPanel().requestRepaint();
+		else
+			handle.getViewerPanel().requestRepaint(interval);
 	}
 
 	private void onBdvSourceChanged() {

--- a/src/main/java/net/imglib2/labkit/brush/FloodFillController.java
+++ b/src/main/java/net/imglib2/labkit/brush/FloodFillController.java
@@ -123,7 +123,7 @@ public class FloodFillController {
 		@Override
 		public void click(int x, int y) {
 			floodFill(displayToImageCoordinates(x, y));
-			model.dataChangedNotifier().notifyListeners();
+			model.dataChangedNotifier().notifyListeners(null);
 		}
 	}
 

--- a/src/main/java/net/imglib2/labkit/labeling/LabelsLayer.java
+++ b/src/main/java/net/imglib2/labkit/labeling/LabelsLayer.java
@@ -3,6 +3,7 @@ package net.imglib2.labkit.labeling;
 
 import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
+import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converters;
 import net.imglib2.labkit.bdv.BdvLayer;
@@ -11,7 +12,7 @@ import net.imglib2.labkit.models.DefaultHolder;
 import net.imglib2.labkit.models.Holder;
 import net.imglib2.labkit.models.LabelingModel;
 import net.imglib2.labkit.utils.ARGBVector;
-import net.imglib2.labkit.utils.Notifier;
+import net.imglib2.labkit.utils.ParametricNotifier;
 import net.imglib2.type.numeric.ARGBType;
 
 import java.util.List;
@@ -27,7 +28,8 @@ public class LabelsLayer implements BdvLayer {
 
 	private final Holder<BdvShowable> showable;
 
-	private final Notifier listeners = new Notifier();
+	private final ParametricNotifier<Interval> listeners =
+		new ParametricNotifier<>();
 
 	private final ARGBType BLACK = new ARGBType(0);
 
@@ -35,12 +37,12 @@ public class LabelsLayer implements BdvLayer {
 		this.model = model;
 		this.showable = new DefaultHolder<>(BdvShowable.wrap(colorView(), model.labelTransformation()));
 		model.labeling().notifier().addListener(this::updateView);
-		model.dataChangedNotifier().addListener(() -> listeners.notifyListeners());
+		model.dataChangedNotifier().addListener(interval -> listeners.notifyListeners(interval));
 	}
 
 	private void updateView() {
 		showable.set(BdvShowable.wrap(colorView(), model.labelTransformation()));
-		listeners.notifyListeners();
+		listeners.notifyListeners(null);
 	}
 
 	private RandomAccessibleInterval<ARGBType> colorView() {
@@ -77,7 +79,7 @@ public class LabelsLayer implements BdvLayer {
 	}
 
 	@Override
-	public Notifier listeners() {
+	public ParametricNotifier<Interval> listeners() {
 		return listeners;
 	}
 

--- a/src/main/java/net/imglib2/labkit/models/ImageLabelingModel.java
+++ b/src/main/java/net/imglib2/labkit/models/ImageLabelingModel.java
@@ -11,8 +11,8 @@ import net.imglib2.labkit.bdv.BdvShowable;
 import net.imglib2.labkit.inputimage.ImgPlusViewsOld;
 import net.imglib2.labkit.inputimage.InputImage;
 import net.imglib2.labkit.labeling.Label;
-import net.imglib2.labkit.utils.Notifier;
 import net.imglib2.labkit.labeling.Labeling;
+import net.imglib2.labkit.utils.ParametricNotifier;
 import net.imglib2.realtransform.AffineTransform3D;
 
 import java.util.Arrays;
@@ -28,7 +28,8 @@ public class ImageLabelingModel implements LabelingModel {
 
 	private Holder<Labeling> labelingHolder;
 
-	private Notifier dataChangedNotifier = new Notifier();
+	private ParametricNotifier<Interval> dataChangedNotifier =
+		new ParametricNotifier<>();
 
 	private Holder<Label> selectedLabelHolder;
 
@@ -113,7 +114,7 @@ public class ImageLabelingModel implements LabelingModel {
 	}
 
 	@Override
-	public Notifier dataChangedNotifier() {
+	public ParametricNotifier<Interval> dataChangedNotifier() {
 		return dataChangedNotifier;
 	}
 

--- a/src/main/java/net/imglib2/labkit/models/LabelingModel.java
+++ b/src/main/java/net/imglib2/labkit/models/LabelingModel.java
@@ -1,9 +1,10 @@
 
 package net.imglib2.labkit.models;
 
+import net.imglib2.Interval;
 import net.imglib2.labkit.labeling.Label;
-import net.imglib2.labkit.utils.Notifier;
 import net.imglib2.labkit.labeling.Labeling;
+import net.imglib2.labkit.utils.ParametricNotifier;
 import net.imglib2.realtransform.AffineTransform3D;
 
 public interface LabelingModel {
@@ -12,7 +13,7 @@ public interface LabelingModel {
 
 	Holder<Labeling> labeling();
 
-	Notifier dataChangedNotifier();
+	ParametricNotifier<Interval> dataChangedNotifier();
 
 	boolean isTimeSeries();
 

--- a/src/main/java/net/imglib2/labkit/project/LabeledImage.java
+++ b/src/main/java/net/imglib2/labkit/project/LabeledImage.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 /**
  * Represents an {@link ImageLabelingModel} that is save to disk.
@@ -44,6 +45,8 @@ public class LabeledImage {
 	private final Holder<Boolean> modified;
 
 	private final Runnable onLabelingChanged = this::onLabelingChanged;
+
+	private final Consumer<Interval> onLabelingChangedConsumer = interval -> onLabelingChanged();
 
 	public LabeledImage(Context context, String imageFile) {
 		this(context, FilenameUtils.getName(imageFile), imageFile, imageFile + ".labeling");
@@ -93,7 +96,7 @@ public class LabeledImage {
 	 */
 	public ImageLabelingModel open() {
 		this.imageLabelingModel = snapshot();
-		imageLabelingModel.dataChangedNotifier().addListener(onLabelingChanged);
+		imageLabelingModel.dataChangedNotifier().addListener(onLabelingChangedConsumer);
 		imageLabelingModel.labeling().notifier().addListener(onLabelingChanged);
 		return imageLabelingModel;
 	}
@@ -105,7 +108,7 @@ public class LabeledImage {
 	public void close() {
 		if (imageLabelingModel == null)
 			return;
-		imageLabelingModel.dataChangedNotifier().removeListener(onLabelingChanged);
+		imageLabelingModel.dataChangedNotifier().removeListener(onLabelingChangedConsumer);
 		imageLabelingModel.labeling().notifier().removeListener(onLabelingChanged);
 		if (storedIn.get() == null) {
 			try {

--- a/src/main/java/net/imglib2/labkit/segmentation/PredictionLayer.java
+++ b/src/main/java/net/imglib2/labkit/segmentation/PredictionLayer.java
@@ -3,6 +3,7 @@ package net.imglib2.labkit.segmentation;
 
 import bdv.util.volatiles.SharedQueue;
 import bdv.util.volatiles.VolatileViews;
+import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
 import net.imglib2.converter.Converters;
@@ -14,7 +15,7 @@ import net.imglib2.labkit.models.ImageLabelingModel;
 import net.imglib2.labkit.models.MappedHolder;
 import net.imglib2.labkit.models.SegmentationModel;
 import net.imglib2.labkit.models.SegmentationResultsModel;
-import net.imglib2.labkit.utils.Notifier;
+import net.imglib2.labkit.utils.ParametricNotifier;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.volatiles.VolatileARGBType;
 import net.imglib2.type.volatiles.VolatileShortType;
@@ -26,7 +27,7 @@ public class PredictionLayer implements BdvLayer {
 		.availableProcessors());
 	private final Holder<Boolean> visibility;
 	private final Runnable classifierChanged = this::classifierChanged;
-	private Notifier listeners = new Notifier();
+	private ParametricNotifier<Interval> listeners = new ParametricNotifier<>();
 	private DefaultHolder<BdvShowable> showable;
 	private final Runnable onTrainingCompleted = this::onTrainingCompleted;
 
@@ -77,7 +78,7 @@ public class PredictionLayer implements BdvLayer {
 			showable.set(BdvShowable.wrap(coloredVolatileView(results)));
 		else
 			showable.set(null);
-		listeners.notifyListeners();
+		listeners.notifyListeners(null);
 	}
 
 	private RandomAccessibleInterval<VolatileARGBType> coloredVolatileView(
@@ -107,7 +108,7 @@ public class PredictionLayer implements BdvLayer {
 	}
 
 	@Override
-	public Notifier listeners() {
+	public ParametricNotifier<Interval> listeners() {
 		return listeners;
 	}
 

--- a/src/main/java/net/imglib2/labkit/utils/ParametricNotifier.java
+++ b/src/main/java/net/imglib2/labkit/utils/ParametricNotifier.java
@@ -1,0 +1,58 @@
+
+package net.imglib2.labkit.utils;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+public class ParametricNotifier<T> {
+
+	private final List<Consumer<T>> listeners = new CopyOnWriteArrayList<>();
+
+	private final List<Reference<? extends Consumer<T>>> weakListeners = new CopyOnWriteArrayList<>();
+
+	private final ReferenceQueue<Consumer<T>> queue = new ReferenceQueue<>();
+
+	public void notifyListeners(T value) {
+		listeners.forEach(listener -> listener.accept(value));
+		cleanWeakListeners();
+		weakListeners.forEach(reference -> {
+			Consumer<T> listener = reference.get();
+			if (listener != null)
+				listener.accept(value);
+		});
+	}
+
+	public void addListener(Consumer<T> listener) {
+		listeners.add(listener);
+	}
+
+	public void removeListener(Consumer<T> listener) {
+		listeners.remove(listener);
+	}
+
+	public void addWeakListener(Consumer<T> listener) {
+		cleanWeakListeners();
+		weakListeners.add(new WeakReference<>(listener, queue));
+	}
+
+	private void cleanWeakListeners() {
+		while (true) {
+			Reference<? extends Consumer<T>> reference = queue.poll();
+			if (reference == null)
+				break;
+			else
+				weakListeners.remove(reference);
+		}
+	}
+
+	public void removeWeakListener(Consumer<T> listener) {
+		weakListeners.removeIf(reference -> {
+			Consumer<T> value = reference.get();
+			return value == null || value == listener;
+		});
+	}
+}


### PR DESCRIPTION
Hi @tpietzsch, 

This is the old branch that I used when coding the interval painting with BDV.
I now see a design problem with it: The code has a Model-View-Controler pattern.
With:
 viewer = BDV
 model = ImageLabelingModel
 controller = LabelBrushController

When the brush is used, the LabelBrushController fires a ImageLabelingModel.dataChangeNotifier().notifyListeners() event. Which tells all the listeners that the content of ImageLabelingModel.labeling() changed. One of the listeneres if th BDV / BasicLabelingComponent, that repaints it screen. This PR adds a "screen interval" as parameter to the event. The controller and viewer can correctly interpret this "screen interval" as they know the current viewer transform. But the other listerners don't know
the current viewer transform. Hence the "screen interval" can not be interpreted correctly by them.

This is not a functional problem, just a little bit dirty about the design. Does any apparent solution come to your mind?