### PR TITLE
SegmentationModel: Add extension points for cached image factory.

### DIFF
--- a/src/main/java/net/imglib2/labkit/models/CachedImageFactory.java
+++ b/src/main/java/net/imglib2/labkit/models/CachedImageFactory.java
@@ -1,0 +1,22 @@
+
+package net.imglib2.labkit.models;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.cache.img.CellLoader;
+import net.imglib2.img.Img;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.labkit.segmentation.Segmenter;
+import net.imglib2.type.NativeType;
+
+import java.util.function.Consumer;
+
+/**
+ * Factory for creating a cached image that stores segmentation/prediction
+ * results
+ */
+public interface CachedImageFactory {
+
+	<T extends NativeType<T>> Img<T> setupCachedImage(Segmenter segmenter,
+		Consumer<RandomAccessibleInterval<T>> loader,
+		CellGrid grid, T type);
+}

--- a/src/main/java/net/imglib2/labkit/models/DefaultCachedImageFactory.java
+++ b/src/main/java/net/imglib2/labkit/models/DefaultCachedImageFactory.java
@@ -1,0 +1,50 @@
+
+package net.imglib2.labkit.models;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.cache.img.CellLoader;
+import net.imglib2.cache.img.DiskCachedCellImgFactory;
+import net.imglib2.cache.img.DiskCachedCellImgOptions;
+import net.imglib2.img.Img;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.labkit.segmentation.Segmenter;
+import net.imglib2.type.NativeType;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+public class DefaultCachedImageFactory implements CachedImageFactory {
+
+	public static CachedImageFactory getInstance() {
+		return new DefaultCachedImageFactory();
+	}
+
+	private DefaultCachedImageFactory() {
+
+	}
+
+	@Override
+	public <T extends NativeType<T>> Img<T> setupCachedImage(Segmenter segmenter,
+		Consumer<RandomAccessibleInterval<T>> loader, CellGrid grid, T type)
+	{
+		final int[] cellDimensions = getCellDimensions(grid);
+		final long[] imgDimensions = grid.getImgDimensions();
+		Arrays.setAll(cellDimensions,
+			i -> (int) Math.min(cellDimensions[i], imgDimensions[i]));
+		DiskCachedCellImgOptions optional = DiskCachedCellImgOptions.options()
+			// .cacheType( CacheType.BOUNDED )
+			// .maxCacheSize( 1000 )
+			.cellDimensions(cellDimensions).initializeCellsAsDirty(true);
+		final DiskCachedCellImgFactory<T> factory =
+			new DiskCachedCellImgFactory<>(type, optional);
+		return factory.create(imgDimensions, loader::accept,
+			DiskCachedCellImgOptions.options().initializeCellsAsDirty(true));
+	}
+
+	private static int[] getCellDimensions(CellGrid grid) {
+		final int[] cellDimensions = new int[grid.numDimensions()];
+		grid.cellDimensions(cellDimensions);
+		return cellDimensions;
+	}
+
+}

--- a/src/main/java/net/imglib2/labkit/models/DefaultSegmentationModel.java
+++ b/src/main/java/net/imglib2/labkit/models/DefaultSegmentationModel.java
@@ -28,11 +28,12 @@ public class DefaultSegmentationModel implements SegmentationModel {
 	private final Context context;
 	private final ImageLabelingModel imageLabelingModel;
 	private final SegmenterListModel segmenterList;
+	private final ExtensionPoints extensionPoints = new ExtensionPoints();
 
 	public DefaultSegmentationModel(Context context, InputImage inputImage) {
 		this.context = context;
 		this.imageLabelingModel = new ImageLabelingModel(inputImage);
-		this.segmenterList = new SegmenterListModel(context);
+		this.segmenterList = new SegmenterListModel(context, extensionPoints);
 		this.segmenterList().trainingData().set(new SingletonTrainingData(imageLabelingModel));
 	}
 
@@ -49,6 +50,10 @@ public class DefaultSegmentationModel implements SegmentationModel {
 	@Override
 	public SegmenterListModel segmenterList() {
 		return segmenterList;
+	}
+
+	public ExtensionPoints extensionPoints() {
+		return extensionPoints;
 	}
 
 	public <T extends IntegerType<T> & NativeType<T>>

--- a/src/main/java/net/imglib2/labkit/models/ExtensionPoints.java
+++ b/src/main/java/net/imglib2/labkit/models/ExtensionPoints.java
@@ -1,0 +1,37 @@
+
+package net.imglib2.labkit.models;
+
+import java.util.Objects;
+
+public class ExtensionPoints {
+
+	/**
+	 * Factory for creating the cached image for segmentation result.
+	 */
+	private CachedImageFactory cachedSegmentationImageFactory;
+
+	/**
+	 * Factory for creating the cached image for prediction result.
+	 */
+	private CachedImageFactory cachedPredictionImageFactory;
+
+	public CachedImageFactory getCachedSegmentationImageFactory() {
+		return cachedSegmentationImageFactory;
+	}
+
+	public void setCachedSegmentationImageFactory(
+		final CachedImageFactory factory)
+	{
+		cachedSegmentationImageFactory = factory;
+	}
+
+	public CachedImageFactory getCachedPredictionImageFactory() {
+		return cachedPredictionImageFactory;
+	}
+
+	public void setCachedPredictionImageFactory(
+		final CachedImageFactory factory)
+	{
+		cachedPredictionImageFactory = factory;
+	}
+}

--- a/src/main/java/net/imglib2/labkit/models/SegmentationItem.java
+++ b/src/main/java/net/imglib2/labkit/models/SegmentationItem.java
@@ -33,9 +33,12 @@ public class SegmentationItem extends ForwardingSegmenter {
 
 	private final Map<ImageLabelingModel, SegmentationResultsModel> results;
 
-	public SegmentationItem(SegmentationPlugin plugin) {
+	private final ExtensionPoints extensionPoints;
+
+	public SegmentationItem(SegmentationPlugin plugin, ExtensionPoints extensionPoints) {
 		super(plugin.createSegmenter());
 		this.name = "#" + counter.incrementAndGet() + " - " + plugin.getTitle();
+		this.extensionPoints = extensionPoints;
 		this.results = new WeakHashMap<>();
 		this.filename = null;
 		this.modified = false;
@@ -53,7 +56,7 @@ public class SegmentationItem extends ForwardingSegmenter {
 	public SegmentationResultsModel results(ImageLabelingModel imageLabeling) {
 		SegmentationResultsModel result = results.get(imageLabeling);
 		if (result == null) {
-			result = new SegmentationResultsModel(imageLabeling, getSourceSegmenter());
+			result = new SegmentationResultsModel(imageLabeling, extensionPoints, getSourceSegmenter());
 			results.put(imageLabeling, result);
 		}
 		return result;

--- a/src/main/java/net/imglib2/labkit/models/SegmentationResultsModel.java
+++ b/src/main/java/net/imglib2/labkit/models/SegmentationResultsModel.java
@@ -5,6 +5,9 @@ import net.imagej.ImgPlus;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.cache.img.CellLoader;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.labkit.inputimage.ImgPlusViewsOld;
 import net.imglib2.labkit.labeling.Labeling;
 import net.imglib2.labkit.segmentation.SegmentationUtils;
 import net.imglib2.labkit.segmentation.Segmenter;
@@ -27,6 +30,7 @@ import java.util.stream.Collectors;
  */
 public class SegmentationResultsModel {
 
+	private final ExtensionPoints extensionPoints;
 	private final ImageLabelingModel model;
 	private final Segmenter segmenter;
 	private boolean hasResults = false;
@@ -37,8 +41,11 @@ public class SegmentationResultsModel {
 
 	private final Notifier listeners = new Notifier();
 
-	public SegmentationResultsModel(ImageLabelingModel model, Segmenter segmenter) {
+	public SegmentationResultsModel(ImageLabelingModel model, ExtensionPoints extensionPoints,
+		Segmenter segmenter)
+	{
 		this.model = model;
+		this.extensionPoints = extensionPoints;
 		this.segmenter = segmenter;
 		segmentation = dummy(new ShortType());
 		prediction = dummy(new FloatType());
@@ -94,12 +101,14 @@ public class SegmentationResultsModel {
 
 	private void updatePrediction(Segmenter segmenter) {
 		ImgPlus<?> image = model.imageForSegmentation().get();
-		this.prediction = SegmentationUtils.createCachedProbabilityMap(segmenter, image);
+		this.prediction = SegmentationUtils.createCachedProbabilityMap(segmenter, image,
+			extensionPoints.getCachedPredictionImageFactory());
 	}
 
 	private void updateSegmentation(Segmenter segmenter) {
 		ImgPlus<?> image = model.imageForSegmentation().get();
-		this.segmentation = SegmentationUtils.createCachedSegmentation(segmenter, image);
+		this.segmentation = SegmentationUtils.createCachedSegmentation(segmenter, image,
+			extensionPoints.getCachedSegmentationImageFactory());
 	}
 
 	public List<String> labels() {

--- a/src/main/java/net/imglib2/labkit/models/SegmenterListModel.java
+++ b/src/main/java/net/imglib2/labkit/models/SegmenterListModel.java
@@ -17,13 +17,15 @@ import java.util.List;
 public class SegmenterListModel {
 
 	private final Context context;
+	private final ExtensionPoints extensionPoints;
 	private final Holder<List<SegmentationItem>> segmenters = new DefaultHolder<>(new ArrayList<>());
 	private final Holder<SegmentationItem> selectedSegmenter = new DefaultHolder<>(null);
 	private final Holder<Boolean> segmentationVisibility = new DefaultHolder<>(true);
 	private final Holder<List<Pair<ImgPlus<?>, Labeling>>> trainingData = new DefaultHolder<>(null);
 
-	public SegmenterListModel(Context context) {
+	public SegmenterListModel(Context context, ExtensionPoints extensionPoints) {
 		this.context = context;
+		this.extensionPoints = extensionPoints;
 		this.segmenters.notifier().addListener(() -> {
 			if (!segmenters.get().contains(selectedSegmenter.get())) selectedSegmenter.set(null);
 		});
@@ -38,7 +40,7 @@ public class SegmenterListModel {
 	}
 
 	public SegmentationItem addSegmenter(SegmentationPlugin plugin) {
-		SegmentationItem segmentationItem = new SegmentationItem(plugin);
+		SegmentationItem segmentationItem = new SegmentationItem(plugin, extensionPoints);
 		segmenters.get().add(segmentationItem);
 		segmenters.notifier().notifyListeners();
 		return segmentationItem;

--- a/src/main/java/net/imglib2/labkit/panel/AddSegmenterPanel.java
+++ b/src/main/java/net/imglib2/labkit/panel/AddSegmenterPanel.java
@@ -1,6 +1,7 @@
 
 package net.imglib2.labkit.panel;
 
+import net.imglib2.labkit.models.ExtensionPoints;
 import net.imglib2.labkit.models.SegmenterListModel;
 import net.imglib2.labkit.segmentation.SegmentationPlugin;
 import net.imglib2.labkit.segmentation.SegmentationPluginService;
@@ -41,7 +42,7 @@ public class AddSegmenterPanel extends JPanel {
 	public static void main(String... args) {
 		JFrame frame = new JFrame("Select Segmentation Algorithm");
 		Context context = SingletonContext.getInstance();
-		SegmenterListModel slm = new SegmenterListModel(context);
+		SegmenterListModel slm = new SegmenterListModel(context, new ExtensionPoints());
 		frame.add(new AddSegmenterPanel(slm));
 		frame.setSize(300, 300);
 		frame.setVisible(true);

--- a/src/main/java/net/imglib2/labkit/plugin/SegmentImageWithLabkitPlugin.java
+++ b/src/main/java/net/imglib2/labkit/plugin/SegmentImageWithLabkitPlugin.java
@@ -9,6 +9,7 @@ import net.imglib2.Interval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.labkit.inputimage.DatasetInputImage;
+import net.imglib2.labkit.models.DefaultCachedImageFactory;
 import net.imglib2.labkit.segmentation.SegmentationUtils;
 import net.imglib2.labkit.segmentation.weka.TrainableSegmentationSegmenter;
 import net.imglib2.labkit.utils.ParallelUtils;
@@ -67,7 +68,7 @@ public class SegmentImageWithLabkitPlugin implements Command, Cancelable {
 	private Img<ShortType> calculateOnCachedImg(TrainableSegmentationSegmenter segmenter,
 		ImgPlus<?> imgPlus)
 	{
-		Img<ShortType> outputImg = SegmentationUtils.createCachedSegmentation(segmenter, imgPlus);
+		Img<ShortType> outputImg = SegmentationUtils.createCachedSegmentation(segmenter, imgPlus, null);
 		ParallelUtils.populateCachedImg(outputImg, new ProgressWriterConsole());
 		return outputImg;
 	}

--- a/src/main/java/net/imglib2/labkit/segmentation/PredictionLayer.java
+++ b/src/main/java/net/imglib2/labkit/segmentation/PredictionLayer.java
@@ -18,6 +18,7 @@ import net.imglib2.labkit.models.SegmentationResultsModel;
 import net.imglib2.labkit.utils.ParametricNotifier;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.ShortType;
 import net.imglib2.type.volatiles.VolatileARGBType;
 import net.imglib2.type.volatiles.VolatileShortType;
 
@@ -98,8 +99,19 @@ public class PredictionLayer implements BdvLayer {
 		SegmentationResultsModel selected)
 	{
 		ARGBType[] colors = selected.colors().toArray(new ARGBType[0]);
-		return mapColors(colors, VolatileViews.wrapAsVolatile(selected
-			.segmentation(), queue));
+		return mapColors(colors, wrapAsVolatile(selected.segmentation()));
+	}
+
+	private RandomAccessibleInterval<VolatileShortType> wrapAsVolatile(
+		RandomAccessibleInterval<ShortType> image)
+	{
+		try {
+			return VolatileViews.wrapAsVolatile(image, queue);
+		}
+		catch (IllegalArgumentException e) {
+			// This happens when image isn't some sort of CachedCellImg.
+			return Converters.convert(image, (i, o) -> o.set(i.get()), new VolatileShortType());
+		}
 	}
 
 	private RandomAccessibleInterval<VolatileARGBType> mapColors(

--- a/src/main/java/net/imglib2/labkit/segmentation/SegmentationUtils.java
+++ b/src/main/java/net/imglib2/labkit/segmentation/SegmentationUtils.java
@@ -6,12 +6,11 @@ import net.imagej.axis.Axes;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.cache.img.CellLoader;
-import net.imglib2.cache.img.DiskCachedCellImgFactory;
-import net.imglib2.cache.img.DiskCachedCellImgOptions;
 import net.imglib2.img.Img;
 import net.imglib2.img.cell.CellGrid;
 import net.imglib2.labkit.inputimage.ImgPlusViewsOld;
+import net.imglib2.labkit.models.CachedImageFactory;
+import net.imglib2.labkit.models.DefaultCachedImageFactory;
 import net.imglib2.labkit.utils.DimensionUtils;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.NumericType;
@@ -28,25 +27,33 @@ public class SegmentationUtils {
 		// prevent from instantiation
 	}
 
-	public static Img<FloatType> createCachedProbabilityMap(Segmenter segmenter, ImgPlus<?> image) {
+	public static Img<FloatType> createCachedProbabilityMap(Segmenter segmenter, ImgPlus<?> image,
+		CachedImageFactory cachedImageFactory)
+	{
+		if (cachedImageFactory == null)
+			cachedImageFactory = DefaultCachedImageFactory.getInstance();
 		int[] cellSize = segmenter.suggestCellSize(image);
-		CellLoader<FloatType> loader = target -> segmenter.predict(image, ensureCellSize(segmenter,
-			cellSize, target));
 		Interval interval = intervalNoChannels(image);
 		int count = segmenter.classNames().size();
 		CellGrid gridWithoutChannels = new CellGrid(Intervals.dimensionsAsLongArray(interval),
 			cellSize);
 		CellGrid gridWithChannel = addDimensionToGrid(count, gridWithoutChannels);
-		return setupCachedImage(loader, gridWithChannel, new FloatType());
+		return cachedImageFactory.setupCachedImage(segmenter,
+			target -> segmenter.predict(image, ensureCellSize(segmenter, cellSize, target)),
+			gridWithChannel, new FloatType());
 	}
 
-	public static Img<ShortType> createCachedSegmentation(Segmenter segmenter, ImgPlus<?> image) {
+	public static Img<ShortType> createCachedSegmentation(Segmenter segmenter, ImgPlus<?> image,
+		CachedImageFactory cachedImageFactory)
+	{
+		if (cachedImageFactory == null)
+			cachedImageFactory = DefaultCachedImageFactory.getInstance();
 		int[] cellSize = segmenter.suggestCellSize(image);
-		CellLoader<ShortType> loader = target -> segmenter.segment(image, ensureCellSize(segmenter,
-			cellSize, target));
 		Interval interval = intervalNoChannels(image);
 		CellGrid grid = new CellGrid(Intervals.dimensionsAsLongArray(interval), cellSize);
-		return setupCachedImage(loader, grid, new ShortType());
+		return cachedImageFactory.setupCachedImage(segmenter,
+			target -> segmenter.segment(image, ensureCellSize(segmenter, cellSize, target)),
+			grid, new ShortType());
 	}
 
 	private static CellGrid addDimensionToGrid(int size, CellGrid grid) {
@@ -79,22 +86,6 @@ public class SegmentationUtils {
 	public static Interval intervalNoChannels(ImgPlus<?> image) {
 		return new FinalInterval(ImgPlusViewsOld.hasAxis(image, Axes.CHANNEL) ? ImgPlusViewsOld
 			.hyperSlice(image, Axes.CHANNEL, 0) : image);
-	}
-
-	private static <T extends NativeType<T>> Img<T> setupCachedImage(
-		CellLoader<T> loader, CellGrid grid, T type)
-	{
-		final int[] cellDimensions = getCellDimensions(grid);
-		final long[] imgDimensions = grid.getImgDimensions();
-		Arrays.setAll(cellDimensions, i -> (int) Math.min(cellDimensions[i], imgDimensions[i]));
-		DiskCachedCellImgOptions optional = DiskCachedCellImgOptions.options()
-			// .cacheType( CacheType.BOUNDED )
-			// .maxCacheSize( 1000 )
-			.cellDimensions(cellDimensions).initializeCellsAsDirty(true);
-		final DiskCachedCellImgFactory<T> factory = new DiskCachedCellImgFactory<>(
-			type, optional);
-		return factory.create(imgDimensions, loader,
-			DiskCachedCellImgOptions.options().initializeCellsAsDirty(true));
 	}
 
 	private static int[] getCellDimensions(CellGrid grid) {

--- a/src/test/java/net/imglib2/labkit/models/CustomCachedImageFactoryDemo.java
+++ b/src/test/java/net/imglib2/labkit/models/CustomCachedImageFactoryDemo.java
@@ -1,0 +1,56 @@
+
+package net.imglib2.labkit.models;
+
+import ij.ImagePlus;
+import net.imagej.ImgPlus;
+import net.imagej.patcher.LegacyInjector;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.VirtualStackAdapter;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.labkit.LabkitFrame;
+import net.imglib2.labkit.inputimage.DatasetInputImage;
+import net.imglib2.labkit.segmentation.Segmenter;
+import net.imglib2.trainable_segmentation.utils.SingletonContext;
+import net.imglib2.type.NativeType;
+
+import java.util.function.Consumer;
+
+/**
+ * {@link SegmentationModel} allows to set a cached image factory via extension
+ * point. This feature allows to customize how the lazy loaded, cached
+ * segmentation and probability maps behave.
+ * <p>
+ * This class demonstrates on such possible customization. It sets a cached
+ * image factory, which for simplicity uses no caching and no lazy loading. It
+ * instead calculates the the entire segmentation (or probability map) an stores
+ * it into a simple ArrayImg.
+ */
+public class CustomCachedImageFactoryDemo {
+
+	static {
+		LegacyInjector.preinit();
+	}
+
+	public static void main(String... args) {
+		final ImagePlus imp = new ImagePlus("https://imagej.nih.gov/ij/images/FluorescentCells.jpg");
+		ImgPlus<?> image = VirtualStackAdapter.wrap(imp);
+		DefaultSegmentationModel segmentationModel = new DefaultSegmentationModel(SingletonContext
+			.getInstance(), new DatasetInputImage(image));
+		segmentationModel.extensionPoints().setCachedSegmentationImageFactory(
+			CustomCachedImageFactoryDemo::noCacheFactory);
+		segmentationModel.extensionPoints().setCachedPredictionImageFactory(
+			CustomCachedImageFactoryDemo::noCacheFactory);
+		LabkitFrame.show(segmentationModel,
+			"Custom Cached Image Factory Demo, That actually uses no cahce.");
+	}
+
+	private static <T extends NativeType<T>> Img<T> noCacheFactory(Segmenter segmenter,
+		Consumer<RandomAccessibleInterval<T>> loader, CellGrid cellGrid, T t)
+	{
+		Img<T> image = new ArrayImgFactory<>(t).create(cellGrid.getImgDimensions());
+		loader.accept(image);
+		return image;
+	}
+}

--- a/src/test/java/net/imglib2/labkit/multi_image/ProjectSegmentationModel.java
+++ b/src/test/java/net/imglib2/labkit/multi_image/ProjectSegmentationModel.java
@@ -3,6 +3,7 @@ package net.imglib2.labkit.multi_image;
 
 import net.imagej.ImgPlus;
 import net.imglib2.labkit.labeling.Labeling;
+import net.imglib2.labkit.models.ExtensionPoints;
 import net.imglib2.labkit.models.ImageLabelingModel;
 import net.imglib2.labkit.project.LabeledImage;
 import net.imglib2.labkit.project.LabkitProjectModel;
@@ -59,7 +60,7 @@ public class ProjectSegmentationModel implements SegmentationModel {
 	}
 
 	private SegmenterListModel initSegmenterListModel(List<String> segmenters) {
-		SegmenterListModel segmenterListModel = new SegmenterListModel(context);
+		SegmenterListModel segmenterListModel = new SegmenterListModel(context, new ExtensionPoints());
 		segmenterListModel.trainingData().set(new TrainingData());
 		for (String filename : segmenters) {
 			SegmentationItem segmentationItem = segmenterListModel.addSegmenter(PixelClassificationPlugin


### PR DESCRIPTION
This allows to customize how Labkit does lazy loading and caching of
the resulting segmentation, and prediction. This might be useful when
Labkit is integrated into other tools.